### PR TITLE
Require all non-dev auth to be @cornell.edu

### DIFF
--- a/server/src/auth/auth.service.ts
+++ b/server/src/auth/auth.service.ts
@@ -89,11 +89,17 @@ export class AuthService {
         idToken = await this.payloadFromApple(token);
         break;
       case AuthType.DEVICE:
-        idToken = { id: token, email: '' };
+        idToken =
+          process.env.DEVELOPMENT === 'true'
+            ? {
+                id: token,
+                email: 'dev@cornell.edu',
+              }
+            : null;
         break;
     }
 
-    if (!idToken) return null;
+    if (!idToken || !idToken.email.endsWith('@cornell.edu')) return null;
 
     let user = await this.userService.byAuth(authType, idToken.id);
 


### PR DESCRIPTION
### Summary

This pull request permits only members of the cornell.edu domain to login.

- [x] Added check for @cornell.edu
- [x] Allowed device login only during testing.

Remaining TODOs:

- [ ] Add google secrets

### Test Plan 

Test that device login only works in staging/review apps/local environment.
