### PR TITLE
Fixed memory usage from 600MB to 248MB.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,4 +18,5 @@ RUN npm run build
 
 WORKDIR /app/server
 COPY server .
-ENTRYPOINT ["npm", "run", "start"]
+RUN npm run build
+ENTRYPOINT ["npm", "run", "start:prod"]

--- a/package.json
+++ b/package.json
@@ -1,8 +1,0 @@
-{
-  "dependencies": {
-    "@mikro-orm/core": "^5.0.5",
-    "@mikro-orm/nestjs": "^5.0.0",
-    "@mikro-orm/postgresql": "^5.0.5",
-    "mikro-orm": "^5.0.5"
-  }
-}

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -40,7 +40,7 @@ const storage = new AsyncLocalStorage<EntityManager>();
       driverOptions: {
         connection: {
           ssl: !process.env.NO_SSL,
-          rejectUnauthorized: !process.env.NO_SSL,
+          rejectUnauthorized: false,
         },
       },
       migrations: {

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -45,6 +45,10 @@ const storage = new AsyncLocalStorage<EntityManager>();
       migrations: {
         path: 'dist/migrations',
         pathTs: 'src/migrations',
+        disableForeignKeys: false,
+      },
+      schemaGenerator: {
+        disableForeignKeys: false,
       },
     }),
     ServeStaticModule.forRoot({

--- a/server/src/app.module.ts
+++ b/server/src/app.module.ts
@@ -39,8 +39,7 @@ const storage = new AsyncLocalStorage<EntityManager>();
       context: () => storage.getStore(), // use our AsyncLocalStorage instance
       driverOptions: {
         connection: {
-          ssl: !process.env.NO_SSL,
-          rejectUnauthorized: false,
+          ssl: !process.env.NO_SSL && { rejectUnauthorized: false },
         },
       },
       migrations: {


### PR DESCRIPTION
### Summary 

This pull request fixes insane memory usage by Nest.js.

- [x] Changed Dockerfile to run start:prod instead of regular start
- [x] Allowed self-signed certs for postgres. 

Remaining TODOs:

- [ ] Check if any ability to debug has changed.
