### PR TITLE
Make progress bar width dynamic based on digit count and shorten larg…

### DIFF
--- a/game/lib/widget/progress_bar.dart
+++ b/game/lib/widget/progress_bar.dart
@@ -12,12 +12,33 @@ class LoadingBar extends StatelessWidget {
     this.totalTasks,
   );
 
+  String formatNumber(int number) {
+    if (number < 1000) {
+      return number.toString();
+    } else {
+      return (number / 1000).toStringAsFixed(1) + 'K';
+    }
+  }
+
+  double calculateWidthMultiplier(int number) {
+    int length = number.toString().length;
+    if (length == 1) {
+      return 0.5;
+    } else if (length == 2) {
+      return 0.47;
+    } else {
+      return 0.43;
+    }
+  }
+
   @override
   Widget build(BuildContext context) {
+    double widthMultiplier = calculateWidthMultiplier(totalTasks);
+
     return Row(
       children: [
         Container(
-            width: MediaQuery.sizeOf(context).width * 0.5,
+            width: MediaQuery.sizeOf(context).width * widthMultiplier,
             child: LayoutBuilder(
                 builder: (BuildContext context, BoxConstraints constraints) {
               return Stack(children: [
@@ -66,7 +87,7 @@ class LoadingBar extends StatelessWidget {
         Padding(
           padding: const EdgeInsets.only(left: 8.0),
           child: Text(
-            tasksFinished.toString() + "/" + totalTasks.toString(),
+            "${formatNumber(tasksFinished)}/${formatNumber(totalTasks)}",
           ),
         ),
       ],


### PR DESCRIPTION
…e numbers

- Adjusted progress bar width to dynamically scale based on the number of digits in total points, achievements, etc., providing better visual alignment.
- Implemented formatting to shorten large numbers (e.g., 1500 becomes 1.5K) for improved readability.

### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards implementing feature Foo

- [x] implemented X
- [x] fixed Y

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] resolve bug 1
- [ ] implement Z

<!--- Note dependencies on other PRs if any. -->

Depends on #{number of PR}


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

### Notes <!-- Optional -->

<!--- List any important or subtle points, future considerations, or other items of note. -->

### Blockers <!-- Optional -->

<!--- Note and itemize any blockers (especially for WIP PRs) here and on Notion -->

- A newly discovered dependency that hasn’t been addressed

### Breaking Changes  <!-- Optional -->

<!-- Keep items that apply: -->

- Database schema change (anything that changes TypeORM entities)
- Other change that could cause problems (Detailed in notes)
