### PR TITLE
Add ability to write latitude and longitude

### DIFF
--- a/admin/src/components/EntryModal.tsx
+++ b/admin/src/components/EntryModal.tsx
@@ -193,29 +193,65 @@ function DraggableMarker(props: {
 }
 
 function MapEntryFormBox(props: { form: MapEntryForm }) {
+  const [lat, setLat] = useState(props.form.latitude);
+  const [lng, setLng] = useState(props.form.longitude);
+
+  useEffect(() => {
+    setLat(props.form.latitude);
+    setLng(props.form.longitude);
+  }, [props.form.latitude, props.form.longitude]);
+
+  const handleLatChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newLat = parseFloat(e.target.value);
+    if (!isNaN(newLat)) {
+      setLat(newLat);
+      props.form.latitude = newLat;
+    }
+  };
+
+  const handleLngChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const newLng = parseFloat(e.target.value);
+    if (!isNaN(newLng)) {
+      setLng(newLng);
+      props.form.longitude = newLng;
+    }
+  };
+
   return (
-    <MapBox>
-      <MapContainer
-        center={[props.form.latitude, props.form.longitude]}
-        zoom={20}
-        style={{
-          width: "100%",
-          height: 300,
-        }}
-      >
-        <TileLayer
-          attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-        />
-        <DraggableMarker
-          center={[props.form.latitude, props.form.longitude]}
-          onLocationChange={(lat, long) => {
-            props.form.latitude = lat;
-            props.form.longitude = long;
+    <>
+      <MapBox>
+        <MapContainer
+          center={[lat, lng]}
+          zoom={20}
+          style={{ 
+            width: "100%", 
+            height: 300,
           }}
-        />
-      </MapContainer>
-    </MapBox>
+        >
+          <TileLayer
+            attribution='&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+            url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+          />
+          <DraggableMarker
+            center={[lat, lng]}
+            onLocationChange={(newLat, newLng) => {
+              setLat(newLat);
+              setLng(newLng);
+              props.form.latitude = newLat;
+              props.form.longitude = newLng;
+            }}
+          />
+        </MapContainer>
+      </MapBox>
+      <EntryBox>
+        <span>Latitude:</span>
+        <EntryTextBox type="number" value={lat} onChange={handleLatChange} />
+      </EntryBox>
+      <EntryBox>
+        <span>Longitude:</span>
+        <EntryTextBox type="number" value={lng} onChange={handleLngChange} />
+      </EntryBox>
+    </>
   );
 }
 


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request adds support for manually inputting latitude and longitude values when creating or editing a challenge.

- [x] Added input fields for latitude and longitude above the map
- [x] Updated map position based on user input

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Remaining TODOs:

- [ ] Test on global Heroku production dashboard


### Test Plan <!-- Required -->

<!-- Provide screenshots or point out the additional unit tests -->

See above
