### PR TITLE
Add 2030 graduation year & Alumni option

### DIFF
--- a/game/lib/details_page/details_page.dart
+++ b/game/lib/details_page/details_page.dart
@@ -68,7 +68,7 @@ class _DetailsPageWidgetState extends State<DetailsPageWidget> {
     "Weill Cornell Medicine"
   ];
 
-  List<String> _years = ["2025", "2026", "2027", "2028", "2029"];
+  List<String> _years = ["2025", "2026", "2027", "2028", "2029", "2030", "Alumni"];
 
   Map<String, List<String>> _majors = {
     "Agriculture and Life Sciences": [

--- a/game/lib/profile/edit_profile.dart
+++ b/game/lib/profile/edit_profile.dart
@@ -247,7 +247,7 @@ class _EditProfileState extends State<EditProfileWidget> {
     "Weill Cornell Medicine": []
   };
 
-  List<String> _years = ["2025", "2026", "2027", "2028", "2029"];
+  List<String> _years = ["2025", "2026", "2027", "2028", "2029", "2030", "Alumni"];
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first step towards implementing feature Foo

- [x] added options for user to select graduation year 2030 (for architecture students) and an alumni option during registration and when editing their profile

<!--- Note dependencies on other PRs if any. -->

Depends on #{number of PR}


### Test Plan <!-- Required -->
- [x] test on different simulators

<!-- Provide screenshots or point out the additional unit tests -->
