### PR TITLE
Minimum Character Requirement for Usernames

### DIFF
--- a/game/lib/details_page/details_page.dart
+++ b/game/lib/details_page/details_page.dart
@@ -38,7 +38,10 @@ Key features include:
 - Form validation using [_formKey]
 - State-managed inputs with real-time updates
 
-This page is a required step in the onboarding process before collecting interests. */
+This page is a required step in the onboarding process before collecting interests.
+
+@remarks
+Form validation ensures that the username is not empty and is at least 3 characters long.*/
 class _DetailsPageWidgetState extends State<DetailsPageWidget> {
   String _name = "";
   String? _college;

--- a/game/lib/details_page/details_page.dart
+++ b/game/lib/details_page/details_page.dart
@@ -276,6 +276,9 @@ class _DetailsPageWidgetState extends State<DetailsPageWidget> {
                           if (value == null || value.isEmpty) {
                             return 'Please enter your username';
                           }
+                          if (value.trim().length < 3) {
+                            return 'Username must be 3 or more characters';
+                          }
                           return null;
                         },
                       ),

--- a/game/lib/profile/edit_profile.dart
+++ b/game/lib/profile/edit_profile.dart
@@ -6,6 +6,8 @@ import 'package:game/progress_indicators/circular_progress_indicator.dart';
 import 'package:game/model/user_model.dart';
 import 'package:provider/provider.dart';
 
+import '../utils/utility_functions.dart';
+
 /**
  * `EditProfileWidget` - A form interface for editing user profile information.
  * 
@@ -293,7 +295,9 @@ class _EditProfileState extends State<EditProfileWidget> {
           String? currMajor = userModel.userData?.major;
 
           // Initialize fields only if they haven't been already
-          if (newUsername == null) newUsername = currUsername ?? '';
+          if (newUsername == null) {
+            newUsername = currUsername ?? '';
+          }
 
           if (newYear == null) {
             newYear = currYear;
@@ -441,6 +445,10 @@ class _EditProfileState extends State<EditProfileWidget> {
                                 onPressed: !fieldsChanged()
                                     ? null
                                     : () {
+                                        if (newUsername == null || newUsername!.trim().length < 3) {
+                                          displayToast("Username must be 3 or more characters", Status.error);
+                                          return;
+                                        }
                                         userModel.updateUserData(
                                             userModel.userData?.id ?? "",
                                             newUsername,

--- a/game/lib/profile/edit_profile.dart
+++ b/game/lib/profile/edit_profile.dart
@@ -22,7 +22,7 @@ import '../utils/utility_functions.dart';
  * - College is not empty
  * - Major is not empty
  * - Graduation Year is not empty
- * - At least one field has bene changed from its original value 
+ * - At least one field has been changed from its original value 
  */
 class EditProfileWidget extends StatefulWidget {
   EditProfileWidget({

--- a/game/lib/profile/edit_profile.dart
+++ b/game/lib/profile/edit_profile.dart
@@ -17,6 +17,12 @@ import '../utils/utility_functions.dart';
  * options and text input for the username. The widget automatically detects changes to
  * enable/disable the update button and communicates with the UserModel to persist changes.
  * 
+ * The conditions for the update button to be enabled are:
+ * - Username is not empty and is at least 3 characters long
+ * - College is not empty
+ * - Major is not empty
+ * - Graduation Year is not empty
+ * - At least one field has bene changed from its original value 
  */
 class EditProfileWidget extends StatefulWidget {
   EditProfileWidget({
@@ -445,8 +451,11 @@ class _EditProfileState extends State<EditProfileWidget> {
                                 onPressed: !fieldsChanged()
                                     ? null
                                     : () {
-                                        if (newUsername == null || newUsername!.trim().length < 3) {
-                                          displayToast("Username must be 3 or more characters", Status.error);
+                                        if (newUsername == null ||
+                                            newUsername!.trim().length < 3) {
+                                          displayToast(
+                                              "Username must be 3 or more characters",
+                                              Status.error);
                                           return;
                                         }
                                         userModel.updateUserData(


### PR DESCRIPTION
### Summary <!-- Required -->

Required users to have a username of at least three characters in the following scenarios:
- [x] when first creating their username during onboarding
- [x] when editing their profile 

### Test Plan <!-- Required -->
- have users try to create accounts and edit their profiles with usernames of length 0, 1, 2, and 3 characters
- try the above with multiple emulators/simulators