### PR TITLE
Camera Integration

### DIFF
--- a/game/android/app/src/main/AndroidManifest.xml
+++ b/game/android/app/src/main/AndroidManifest.xml
@@ -2,6 +2,7 @@
   <uses-permission android:name="android.permission.INTERNET" />
   <uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
   <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+  <uses-permission android:name="android.permission.CAMERA" />
   <application android:label="CornellGO" android:icon="@mipmap/launcher_icon">
     
     <meta-data android:name="com.google.android.geo.API_KEY"

--- a/game/ios/Podfile.lock
+++ b/game/ios/Podfile.lock
@@ -5,6 +5,8 @@ PODS:
   - AppAuth/Core (1.7.5)
   - AppAuth/ExternalUserAgent (1.7.5):
     - AppAuth/Core
+  - camera_avfoundation (0.0.1):
+    - Flutter
   - device_info_plus (0.0.1):
     - Flutter
   - Firebase (11.3.0):
@@ -157,6 +159,7 @@ PODS:
     - Flutter
 
 DEPENDENCIES:
+  - camera_avfoundation (from `.symlinks/plugins/camera_avfoundation/ios`)
   - device_info_plus (from `.symlinks/plugins/device_info_plus/ios`)
   - Firebase
   - Firebase/Analytics
@@ -195,6 +198,8 @@ SPEC REPOS:
     - PromisesObjC
 
 EXTERNAL SOURCES:
+  camera_avfoundation:
+    :path: ".symlinks/plugins/camera_avfoundation/ios"
   device_info_plus:
     :path: ".symlinks/plugins/device_info_plus/ios"
   Flutter:
@@ -230,13 +235,14 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   AppAuth: 501c04eda8a8d11f179dbe8637b7a91bb7e5d2fa
+  camera_avfoundation: be3be85408cd4126f250386828e9b1dfa40ab436
   device_info_plus: 335f3ce08d2e174b9fdc3db3db0f4e3b1f66bd89
   Firebase: 5c575140761e22324806f401e38c483d58db2dec
   FirebaseAnalytics: ce1593872635a5ebd715d0d3937fab195991ecc9
   FirebaseCore: 8542de610f35f86196ba26cdb2544565a5157c8e
   FirebaseCoreInternal: ac26d09a70c730e497936430af4e60fb0c68ec4e
   FirebaseInstallations: 58cf94dabf1e2bb2fa87725a9be5c2249171cda0
-  Flutter: cabc95a1d2626b1b06e7179b784ebcf0c0cde467
+  Flutter: e0871f40cf51350855a761d2e70bf5af5b9b5de7
   flutter_compass: b236ab69b61545cce89fd58527f401a7587d5cc1
   flutter_config_plus: f980f190875b1d53f7d7bfc242f65d844faf561d
   flutter_secure_storage: 1ed9476fba7e7a782b22888f956cce43e2c62f13

--- a/game/ios/Runner.xcodeproj/project.pbxproj
+++ b/game/ios/Runner.xcodeproj/project.pbxproj
@@ -212,9 +212,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Copy Pods Resources";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-resources-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -282,9 +286,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -370,7 +378,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Profile;
@@ -460,7 +468,7 @@
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 			};
 			name = Debug;
 		};
@@ -510,7 +518,7 @@
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = iphoneos;
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				TARGETED_DEVICE_FAMILY = "1";
+				TARGETED_DEVICE_FAMILY = 1;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;

--- a/game/ios/Runner/Info.plist
+++ b/game/ios/Runner/Info.plist
@@ -39,6 +39,8 @@
 	<false/>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>CornellGO uses the camera so you can take a completion photo for challenges and journeys.</string>
 	<key>NSLocationAlwaysAndWhenInUseUsageDescription</key>
 	<string>We use your location to help improve your experience using CornellGo, including detecting when you have successfully found an event's location so you can gain points and move on to the next challenge.</string>
 	<key>NSLocationAlwaysUsageDescription</key>
@@ -61,7 +63,6 @@
 	<array>
 		<string>UIInterfaceOrientationPortrait</string>
 	</array>
-
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
 </dict>

--- a/game/lib/gameplay/arrival_dialog.dart
+++ b/game/lib/gameplay/arrival_dialog.dart
@@ -7,7 +7,7 @@ import 'package:game/api/game_client_dto.dart';
 import 'package:game/model/event_model.dart';
 import 'package:game/model/tracker_model.dart';
 import 'package:game/model/group_model.dart';
-import 'package:game/gameplay/challenge_completed.dart';
+import 'package:game/gameplay/take_photo_page.dart';
 import 'package:game/quiz/quiz_page.dart';
 import 'package:game/gameplay/gameplay_page.dart';
 
@@ -222,8 +222,7 @@ class _ButtonRow extends StatelessWidget {
                 Navigator.pushReplacement(
                   context,
                   MaterialPageRoute(
-                    builder: (context) =>
-                        ChallengeCompletedPage(challengeId: challengeId),
+                    builder: (context) => TakePhotoPage(challengeId: challengeId),
                   ),
                 );
               }

--- a/game/lib/gameplay/gameplay_map.dart
+++ b/game/lib/gameplay/gameplay_map.dart
@@ -8,7 +8,7 @@ import 'package:geolocator/geolocator.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 import 'dart:async';
 import 'dart:math';
-import 'package:game/gameplay/challenge_completed.dart';
+import 'package:game/gameplay/take_photo_page.dart';
 import 'package:game/gameplay/challenge_failed.dart';
 import 'package:game/utils/utility_functions.dart';
 import 'dart:ui' as ui;
@@ -2763,7 +2763,7 @@ class _GameplayMapState extends State<GameplayMap>
                       Navigator.pushReplacement(
                         context,
                         MaterialPageRoute(
-                            builder: (context) => ChallengeCompletedPage(
+                            builder: (context) => TakePhotoPage(
                                   challengeId: challengeId,
                                 )),
                       );

--- a/game/lib/gameplay/take_photo_page.dart
+++ b/game/lib/gameplay/take_photo_page.dart
@@ -6,6 +6,10 @@ import 'package:permission_handler/permission_handler.dart';
 
 import 'package:game/gameplay/challenge_completed.dart';
 
+"""
+Camera capture for a challenge completion photo.
+On success, the primary action continues to [ChallengeCompletedPage]
+"""
 class TakePhotoPage extends StatefulWidget {
   final String challengeId;
 

--- a/game/lib/gameplay/take_photo_page.dart
+++ b/game/lib/gameplay/take_photo_page.dart
@@ -6,10 +6,10 @@ import 'package:permission_handler/permission_handler.dart';
 
 import 'package:game/gameplay/challenge_completed.dart';
 
-"""
-Camera capture for a challenge completion photo.
-On success, the primary action continues to [ChallengeCompletedPage]
-"""
+
+// Camera capture for a challenge completion photo.
+// On success, the primary action continues to [ChallengeCompletedPage]
+
 class TakePhotoPage extends StatefulWidget {
   final String challengeId;
 

--- a/game/lib/gameplay/take_photo_page.dart
+++ b/game/lib/gameplay/take_photo_page.dart
@@ -1,0 +1,343 @@
+import 'dart:io';
+
+import 'package:camera/camera.dart';
+import 'package:flutter/material.dart';
+import 'package:permission_handler/permission_handler.dart';
+
+import 'package:game/gameplay/challenge_completed.dart';
+
+class TakePhotoPage extends StatefulWidget {
+  final String challengeId;
+
+  const TakePhotoPage({
+    super.key,
+    required this.challengeId,
+  });
+
+  @override
+  State<TakePhotoPage> createState() => _TakePhotoPageState();
+}
+
+class _TakePhotoPageState extends State<TakePhotoPage> {
+  CameraController? _controller;
+  Future<void>? _initializeControllerFuture;
+  String? _capturedImagePath;
+  bool _isLoadingCamera = true;
+  bool _cameraPermissionDenied = false;
+  String? _cameraError;
+
+  @override
+  void initState() {
+    super.initState();
+    _setupCamera();
+  }
+
+  Future<void> _setupCamera() async {
+    setState(() {
+      _isLoadingCamera = true;
+      _cameraPermissionDenied = false;
+      _cameraError = null;
+    });
+
+    final status = await Permission.camera.request();
+    if (!status.isGranted) {
+      if (!mounted) return;
+      setState(() {
+        _isLoadingCamera = false;
+        _cameraPermissionDenied = true;
+      });
+      return;
+    }
+
+    try {
+      final cameras = await availableCameras();
+      if (cameras.isEmpty) {
+        if (!mounted) return;
+        setState(() {
+          _isLoadingCamera = false;
+          _cameraError = 'No camera is available on this device.';
+        });
+        return;
+      }
+
+      final selectedCamera = cameras.first;
+      final controller = CameraController(
+        selectedCamera,
+        ResolutionPreset.medium,
+        enableAudio: false,
+      );
+
+      final initializeFuture = controller.initialize();
+
+      if (!mounted) {
+        await controller.dispose();
+        return;
+      }
+
+      setState(() {
+        _controller = controller;
+        _initializeControllerFuture = initializeFuture;
+        _capturedImagePath = null;
+      });
+
+      await initializeFuture;
+      if (!mounted) return;
+
+      setState(() {
+        _isLoadingCamera = false;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      setState(() {
+        _isLoadingCamera = false;
+        _cameraError = 'Unable to open the camera. Please try again.';
+      });
+    }
+  }
+
+  Future<void> _capturePhoto() async {
+    final controller = _controller;
+    final initializeFuture = _initializeControllerFuture;
+    if (controller == null || initializeFuture == null) return;
+
+    try {
+      await initializeFuture;
+      final image = await controller.takePicture();
+      if (!mounted) return;
+      setState(() {
+        _capturedImagePath = image.path;
+      });
+    } catch (_) {
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        const SnackBar(content: Text('Could not capture photo. Please retry.')),
+      );
+    }
+  }
+
+  void _retakePhoto() {
+    setState(() {
+      _capturedImagePath = null;
+    });
+  }
+
+  void _saveAndContinue() {
+    Navigator.pushReplacement(
+      context,
+      MaterialPageRoute(
+        builder: (context) => ChallengeCompletedPage(
+          challengeId: widget.challengeId,
+        ),
+      ),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller?.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      backgroundColor: const Color(0xFFF9F5F1),
+      appBar: AppBar(
+        backgroundColor: Colors.white,
+        elevation: 0,
+        iconTheme: const IconThemeData(color: Colors.black87),
+        title: const Text(
+          'Take a picture',
+          style: TextStyle(color: Colors.black87, fontWeight: FontWeight.w600),
+        ),
+      ),
+      body: SafeArea(child: _buildBody()),
+    );
+  }
+
+  Widget _buildBody() {
+    if (_isLoadingCamera) {
+      return const Center(child: CircularProgressIndicator());
+    }
+
+    if (_cameraPermissionDenied) {
+      return _DeniedState(
+        onTryAgain: _setupCamera,
+      );
+    }
+
+    if (_cameraError != null) {
+      return Center(
+        child: Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 24),
+          child: Text(
+            _cameraError!,
+            textAlign: TextAlign.center,
+            style: const TextStyle(fontSize: 16),
+          ),
+        ),
+      );
+    }
+
+    if (_capturedImagePath != null) {
+      return _PreviewState(
+        imagePath: _capturedImagePath!,
+        onRetake: _retakePhoto,
+        onSaveToAlbum: _saveAndContinue,
+      );
+    }
+
+    final controller = _controller;
+    final initializeFuture = _initializeControllerFuture;
+    if (controller == null || initializeFuture == null) {
+      return const SizedBox.shrink();
+    }
+
+    return Column(
+      children: [
+        Expanded(
+          child: Padding(
+            padding: const EdgeInsets.all(16),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: FutureBuilder<void>(
+                future: initializeFuture,
+                builder: (context, snapshot) {
+                  if (snapshot.connectionState == ConnectionState.done) {
+                    return CameraPreview(controller);
+                  }
+                  return const Center(child: CircularProgressIndicator());
+                },
+              ),
+            ),
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.only(bottom: 24, top: 8),
+          child: GestureDetector(
+            onTap: _capturePhoto,
+            child: Container(
+              width: 78,
+              height: 78,
+              decoration: BoxDecoration(
+                shape: BoxShape.circle,
+                border: Border.all(color: const Color(0xFFE95755), width: 4),
+              ),
+              child: const Center(
+                child: CircleAvatar(
+                  radius: 28,
+                  backgroundColor: Color(0xFFE95755),
+                ),
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _PreviewState extends StatelessWidget {
+  final String imagePath;
+  final VoidCallback onRetake;
+  final VoidCallback onSaveToAlbum;
+
+  const _PreviewState({
+    required this.imagePath,
+    required this.onRetake,
+    required this.onSaveToAlbum,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          Expanded(
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(16),
+              child: Image.file(
+                File(imagePath),
+                width: double.infinity,
+                fit: BoxFit.cover,
+              ),
+            ),
+          ),
+          const SizedBox(height: 20),
+          SizedBox(
+            width: double.infinity,
+            child: ElevatedButton(
+              onPressed: onSaveToAlbum,
+              style: ElevatedButton.styleFrom(
+                backgroundColor: const Color(0xFFE95755),
+                padding: const EdgeInsets.symmetric(vertical: 14),
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(12),
+                ),
+              ),
+              child: const Text(
+                'Save to Album',
+                style: TextStyle(
+                  color: Colors.white,
+                  fontSize: 18,
+                  fontWeight: FontWeight.w600,
+                ),
+              ),
+            ),
+          ),
+          const SizedBox(height: 10),
+          TextButton(
+            onPressed: onRetake,
+            child: const Text(
+              'Retake',
+              style: TextStyle(
+                color: Colors.black87,
+                fontSize: 18,
+                fontWeight: FontWeight.w500,
+              ),
+            ),
+          ),
+          const SizedBox(height: 6),
+        ],
+      ),
+    );
+  }
+}
+
+class _DeniedState extends StatelessWidget {
+  final VoidCallback onTryAgain;
+
+  const _DeniedState({
+    required this.onTryAgain,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.symmetric(horizontal: 24),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            const Text(
+              'Camera access is required to take your completion photo.',
+              textAlign: TextAlign.center,
+              style: TextStyle(fontSize: 16),
+            ),
+            const SizedBox(height: 16),
+            ElevatedButton(
+              onPressed: onTryAgain,
+              child: const Text('Try Again'),
+            ),
+            const SizedBox(height: 8),
+            TextButton(
+              onPressed: openAppSettings,
+              child: const Text('Open Settings'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/game/lib/quiz/quiz_page.dart
+++ b/game/lib/quiz/quiz_page.dart
@@ -8,7 +8,7 @@ import 'package:game/model/event_model.dart';
 import 'package:game/model/tracker_model.dart';
 import 'package:game/model/group_model.dart';
 import 'package:game/model/challenge_model.dart';
-import 'package:game/gameplay/challenge_completed.dart';
+import 'package:game/gameplay/take_photo_page.dart';
 import 'package:game/gameplay/gameplay_page.dart';
 import 'package:game/utils/utility_functions.dart';
 import 'package:flutter/scheduler.dart';
@@ -104,7 +104,7 @@ class _QuizScreenState extends State<_QuizScreen> {
                 Navigator.pushReplacement(
                   context,
                   MaterialPageRoute(
-                    builder: (context) => ChallengeCompletedPage(
+                    builder: (context) => TakePhotoPage(
                       challengeId: widget.challengeId,
                     ),
                   ),
@@ -584,8 +584,7 @@ class _QuizScreenState extends State<_QuizScreen> {
                                   Navigator.pushReplacement(
                                     context,
                                     MaterialPageRoute(
-                                      builder: (context) =>
-                                          ChallengeCompletedPage(
+                                      builder: (context) => TakePhotoPage(
                                         challengeId: widget.challengeId,
                                       ),
                                     ),

--- a/game/pubspec.lock
+++ b/game/pubspec.lock
@@ -65,6 +65,46 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
+  camera:
+    dependency: "direct main"
+    description:
+      name: camera
+      sha256: "87a27e0553e3432119c1c2f6e4b9a1bbf7d2c660552b910bfa59185a9facd632"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.11.2+1"
+  camera_android_camerax:
+    dependency: transitive
+    description:
+      name: camera_android_camerax
+      sha256: "58b8fe843a3c83fd1273c00cb35f5a8ae507f6cc9b2029bcf7e2abba499e28d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.19+1"
+  camera_avfoundation:
+    dependency: transitive
+    description:
+      name: camera_avfoundation
+      sha256: "951ef122d01ebba68b7a54bfe294e8b25585635a90465c311b2f875ae72c412f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.21+2"
+  camera_platform_interface:
+    dependency: transitive
+    description:
+      name: camera_platform_interface
+      sha256: "98cfc9357e04bad617671b4c1f78a597f25f08003089dd94050709ae54effc63"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.12.0"
+  camera_web:
+    dependency: transitive
+    description:
+      name: camera_web
+      sha256: "595f28c89d1fb62d77c73c633193755b781c6d2e0ebcd8dc25b763b514e6ba8f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5"
   carousel_slider:
     dependency: "direct main"
     description:
@@ -121,6 +161,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.0"
+  cross_file:
+    dependency: transitive
+    description:
+      name: cross_file
+      sha256: "942a4791cd385a68ccb3b32c71c427aba508a1bb949b86dff2adbe4049f16239"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.5"
   crypto:
     dependency: transitive
     description:
@@ -181,10 +229,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -609,26 +657,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   linkify:
     dependency: transitive
     description:
@@ -713,10 +761,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1174,10 +1222,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.4"
   tuple:
     dependency: "direct main"
     description:
@@ -1302,10 +1350,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   velocity_x:
     dependency: "direct main"
     description:
@@ -1387,5 +1435,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/game/pubspec.yaml
+++ b/game/pubspec.yaml
@@ -65,6 +65,7 @@ dependencies:
   device_preview: ^1.2.0
   showcaseview: ^5.0.1
   flutter_compass: ^0.8.0
+  camera: ^0.11.2+1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
### Summary <!-- Required -->

<!-- Provide a general summary of your changes in the Title above -->
<!-- Itemize bug fixes, new features, and other changes -->
<!-- Feel free to break this into sub-sections, i.e. features, fixes, etc. -->
<!-- Some examples are shown below. -->

This pull request is the first frontend step of implementing “take a photo” feature that runs right before the Challenge Complete / Journey Complete screen. User should be able to take a photo, then choose to retake or proceed.

<!--- Itemize any relevant remaining TODOs (especially for WIP PRs) here and on Notion -->

Camera Integration:

- [x] created a TakePhotoPage that uses the camera plugin to capture a photo after a challenge and continues the completion flow
- [x] added Android and iOS camera usage permissions and native project updates so the app can request and use the camera
- [x] replaced direct navigation to ChallengeCompletedPage with TakePhotoPage from the arrival dialog, gameplay map, and quiz completion paths so every completion goes through the photo step first


### Test Plan <!-- Required -->
- grant permission → preview → capture → continue
- challenge → take photo → completed
- each challenge in journey → take photo → completed 
- retake after capture 