### PR TITLE
Add scheduled times for challes in journeys

### DIFF
--- a/admin/src/all.dto.ts
+++ b/admin/src/all.dto.ts
@@ -143,6 +143,18 @@ export enum CheckInErrorCodeDto {
   UNKNOWN_ERROR = 'UNKNOWN_ERROR',
 }
 
+export enum ClubSubmissionCategoryDto {
+  SOCIAL = 'SOCIAL',
+  CULTURAL = 'CULTURAL',
+  ATHLETIC = 'ATHLETIC',
+  WELLNESS = 'WELLNESS',
+  ACADEMIC = 'ACADEMIC',
+  ARTS = 'ARTS',
+  CAREER = 'CAREER',
+  COMMUNITY = 'COMMUNITY',
+  OTHER = 'OTHER',
+}
+
 export enum EventCategoryDto {
   FOOD = 'FOOD',
   NATURE = 'NATURE',
@@ -448,6 +460,8 @@ export interface ChallengeDto {
   closeRadiusF?: number;
   linkedEventId?: string;
   timerLength?: number;
+  scheduledStartTime?: string;
+  scheduledEndTime?: string;
 }
 
 export interface RequestChallengeDataDto {
@@ -515,6 +529,7 @@ export interface ClubSubmissionDto {
   location: string;
   latitude?: number;
   longitude?: number;
+  category: ClubSubmissionCategoryDto;
   address?: string;
   imageUrl?: string;
   registrationLink?: string;
@@ -588,6 +603,7 @@ export interface PrevChallengeDto {
   extensionsUsed?: number;
   dateCompleted: string;
   failed?: boolean;
+  dateExpired?: boolean;
 }
 
 export interface EventTrackerDto {

--- a/admin/src/components/ChallengeCardComponents.tsx
+++ b/admin/src/components/ChallengeCardComponents.tsx
@@ -12,6 +12,7 @@ import {
   OptionEntryForm,
   MapEntryForm,
   CheckboxNumberEntryForm,
+  CheckboxDateEntryForm,
   AnswersEntryForm,
   OptionWithCustomEntryForm,
 } from './EntryModal';
@@ -223,6 +224,16 @@ export function makeChallengeForm(): EntryForm[] {
       max: 3600,
       numberLabel: 'Timer Length (seconds)',
     },
+    {
+      name: 'Scheduled Start Time',
+      checked: false,
+      date: new Date(),
+    },
+    {
+      name: 'Scheduled End Time',
+      checked: false,
+      date: new Date(),
+    },
   ];
 }
 
@@ -285,6 +296,20 @@ export function challengeToForm(challenge: ChallengeDto) {
       max: 3600,
       numberLabel: 'Timer Length (seconds)',
     },
+    {
+      name: 'Scheduled Start Time',
+      checked: !!challenge.scheduledStartTime,
+      date: challenge.scheduledStartTime
+        ? new Date(challenge.scheduledStartTime)
+        : new Date(),
+    },
+    {
+      name: 'Scheduled End Time',
+      checked: !!challenge.scheduledEndTime,
+      date: challenge.scheduledEndTime
+        ? new Date(challenge.scheduledEndTime)
+        : new Date(),
+    },
   ];
 }
 
@@ -294,6 +319,8 @@ export function challengeFromForm(
   id: string,
 ): ChallengeDto {
   const timerForm = form[8] as CheckboxNumberEntryForm;
+  const startForm = form[9] as CheckboxDateEntryForm;
+  const endForm = form[10] as CheckboxDateEntryForm;
   return {
     id,
     name: (form[2] as FreeEntryForm).value,
@@ -307,6 +334,10 @@ export function challengeFromForm(
     closeRadiusF: (form[7] as NumberEntryForm).value,
     linkedEventId: eventId,
     timerLength: timerForm.checked ? timerForm.value : undefined,
+    scheduledStartTime: startForm.checked
+      ? startForm.date.toISOString()
+      : undefined,
+    scheduledEndTime: endForm.checked ? endForm.date.toISOString() : undefined,
   };
 }
 
@@ -410,6 +441,14 @@ export function ChallengeCard(props: {
         <b>
           {props.challenge.timerLength
             ? `${Math.floor(props.challenge.timerLength / 60)}m ${props.challenge.timerLength % 60}s`
+            : 'None'}
+        </b>
+        <br />
+        Scheduled:{' '}
+        <b>
+          {props.challenge.scheduledStartTime ||
+          props.challenge.scheduledEndTime
+            ? `${props.challenge.scheduledStartTime ? new Date(props.challenge.scheduledStartTime).toLocaleString() : '—'} to ${props.challenge.scheduledEndTime ? new Date(props.challenge.scheduledEndTime).toLocaleString() : '—'}`
             : 'None'}
         </b>
       </ListCardBody>

--- a/admin/src/components/EntryModal.tsx
+++ b/admin/src/components/EntryModal.tsx
@@ -60,6 +60,12 @@ export type AnswersEntryForm = {
   maxAnswers: number;
 };
 
+export type CheckboxDateEntryForm = {
+  name: string;
+  checked: boolean;
+  date: Date;
+};
+
 export type OptionWithCustomEntryForm = {
   name: string;
   value: number;
@@ -76,7 +82,8 @@ export type EntryForm =
   | DateEntryForm
   | CheckboxNumberEntryForm
   | AnswersEntryForm
-  | OptionWithCustomEntryForm;
+  | OptionWithCustomEntryForm
+  | CheckboxDateEntryForm;
 
 const EntryBox = styled.div`
   margin-bottom: 12px;
@@ -248,6 +255,46 @@ function CheckboxNumberEntryFormBox(props: { form: CheckboxNumberEntryForm }) {
             onChange={e => {
               setVal(e.target.value);
               props.form.value = +e.target.value;
+            }}
+          />
+        </EntryBox>
+      )}
+    </>
+  );
+}
+
+function CheckboxDateEntryFormBox(props: { form: CheckboxDateEntryForm }) {
+  const [checked, setChecked] = useState(props.form.checked);
+  const [val, setVal] = useState('');
+
+  useEffect(() => {
+    setChecked(props.form.checked);
+    setVal(props.form.date.toISOString().slice(0, 16));
+  }, [props.form]);
+
+  return (
+    <>
+      <EntryBox>
+        <label>
+          <input
+            type="checkbox"
+            checked={checked}
+            onChange={e => {
+              setChecked(e.target.checked);
+              props.form.checked = e.target.checked;
+            }}
+          />
+          {' ' + props.form.name}
+        </label>
+      </EntryBox>
+      {checked && (
+        <EntryBox>
+          <EntryTextBox
+            type="datetime-local"
+            value={val}
+            onChange={e => {
+              setVal(e.target.value);
+              props.form.date = new Date(e.target.value);
             }}
           />
         </EntryBox>
@@ -607,6 +654,8 @@ export function EntryModal(props: {
           return <OptionEntryFormBox form={form} key={form.name} />;
         } else if ('characterLimit' in form) {
           return <FreeEntryFormBox form={form} key={form.name} />;
+        } else if ('date' in form && 'checked' in form) {
+          return <CheckboxDateEntryFormBox form={form} key={form.name} />;
         } else if ('checked' in form) {
           return <CheckboxNumberEntryFormBox form={form} key={form.name} />;
         } else if ('min' in form) {

--- a/admin/src/components/ServerApi.tsx
+++ b/admin/src/components/ServerApi.tsx
@@ -21,12 +21,14 @@ export class ServerApi {
 
   requestAchievementTrackerData(data: dto.RequestAchievementTrackerDataDto) {
     return this.send('requestAchievementTrackerData', data) as Promise<
-      any | undefined
+      number | undefined
     >;
   }
 
   updateAchievementData(data: dto.UpdateAchievementDataDto) {
-    return this.send('updateAchievementData', data) as Promise<any | undefined>;
+    return this.send('updateAchievementData', data) as Promise<
+      string | undefined
+    >;
   }
 
   requestBearItems(data: dto.RequestBearItemsDto) {
@@ -60,7 +62,7 @@ export class ServerApi {
   }
 
   updateBearItemData(data: dto.UpdateBearItemDataDto) {
-    return this.send('updateBearItemData', data) as Promise<any | undefined>;
+    return this.send('updateBearItemData', data) as Promise<string | undefined>;
   }
 
   requestCampusEvents(data: dto.RequestCampusEventsDto) {
@@ -82,11 +84,11 @@ export class ServerApi {
   }
 
   createCampusEvent(data: dto.UpsertCampusEventDto) {
-    return this.send('createCampusEvent', data) as Promise<any | undefined>;
+    return this.send('createCampusEvent', data) as Promise<string | undefined>;
   }
 
   updateCampusEvent(data: dto.UpsertCampusEventDto) {
-    return this.send('updateCampusEvent', data) as Promise<any | undefined>;
+    return this.send('updateCampusEvent', data) as Promise<string | undefined>;
   }
 
   deleteCampusEvent(data: dto.DeleteCampusEventDto) {
@@ -118,11 +120,13 @@ export class ServerApi {
   }
 
   completedChallenge(data: dto.CompletedChallengeDto) {
-    return this.send('completedChallenge', data) as Promise<any | undefined>;
+    return this.send('completedChallenge', data) as Promise<string | undefined>;
   }
 
   updateChallengeData(data: dto.UpdateChallengeDataDto) {
-    return this.send('updateChallengeData', data) as Promise<any | undefined>;
+    return this.send('updateChallengeData', data) as Promise<
+      string | undefined
+    >;
   }
 
   checkInWithLocation(data: dto.LocationCheckInDto) {
@@ -159,7 +163,7 @@ export class ServerApi {
 
   requestEventTrackerData(data: dto.RequestEventTrackerDataDto) {
     return this.send('requestEventTrackerData', data) as Promise<
-      any | undefined
+      number | undefined
     >;
   }
 
@@ -170,7 +174,7 @@ export class ServerApi {
   }
 
   updateEventData(data: dto.UpdateEventDataDto) {
-    return this.send('updateEventData', data) as Promise<any | undefined>;
+    return this.send('updateEventData', data) as Promise<string | undefined>;
   }
 
   triggerEventSync(data: dto.TriggerEventSyncDto) {
@@ -227,13 +231,13 @@ export class ServerApi {
 
   requestOrganizationData(data: dto.RequestOrganizationDataDto) {
     return this.send('requestOrganizationData', data) as Promise<
-      any | undefined
+      number | undefined
     >;
   }
 
   updateOrganizationData(data: dto.UpdateOrganizationDataDto) {
     return this.send('updateOrganizationData', data) as Promise<
-      any | undefined
+      string | undefined
     >;
   }
 
@@ -308,7 +312,7 @@ export class ServerApi {
   }
 
   addManager(data: dto.AddManagerDto) {
-    return this.send('addManager', data) as Promise<any | undefined>;
+    return this.send('addManager', data) as Promise<string | undefined>;
   }
 
   joinOrganization(data: dto.JoinOrganizationDto) {

--- a/game/lib/api/game_client_dto.dart
+++ b/game/lib/api/game_client_dto.dart
@@ -143,6 +143,18 @@ enum CheckInErrorCodeDto {
   UNKNOWN_ERROR,
 }
 
+enum ClubSubmissionCategoryDto {
+  SOCIAL,
+  CULTURAL,
+  ATHLETIC,
+  WELLNESS,
+  ACADEMIC,
+  ARTS,
+  CAREER,
+  COMMUNITY,
+  OTHER,
+}
+
 enum EventCategoryDto {
   FOOD,
   NATURE,
@@ -1690,6 +1702,12 @@ class ChallengeDto {
     if (timerLength != null) {
       fields['timerLength'] = timerLength;
     }
+    if (scheduledStartTime != null) {
+      fields['scheduledStartTime'] = scheduledStartTime;
+    }
+    if (scheduledEndTime != null) {
+      fields['scheduledEndTime'] = scheduledEndTime;
+    }
     return fields;
   }
 
@@ -1715,6 +1733,12 @@ class ChallengeDto {
         fields.containsKey('linkedEventId') ? (fields["linkedEventId"]) : null;
     timerLength =
         fields.containsKey('timerLength') ? (fields["timerLength"]) : null;
+    scheduledStartTime = fields.containsKey('scheduledStartTime')
+        ? (fields["scheduledStartTime"])
+        : null;
+    scheduledEndTime = fields.containsKey('scheduledEndTime')
+        ? (fields["scheduledEndTime"])
+        : null;
   }
 
   void partialUpdate(ChallengeDto other) {
@@ -1733,6 +1757,12 @@ class ChallengeDto {
     linkedEventId =
         other.linkedEventId == null ? linkedEventId : other.linkedEventId;
     timerLength = other.timerLength == null ? timerLength : other.timerLength;
+    scheduledStartTime = other.scheduledStartTime == null
+        ? scheduledStartTime
+        : other.scheduledStartTime;
+    scheduledEndTime = other.scheduledEndTime == null
+        ? scheduledEndTime
+        : other.scheduledEndTime;
   }
 
   ChallengeDto({
@@ -1748,6 +1778,8 @@ class ChallengeDto {
     this.closeRadiusF,
     this.linkedEventId,
     this.timerLength,
+    this.scheduledStartTime,
+    this.scheduledEndTime,
   });
 
   late String id;
@@ -1762,6 +1794,8 @@ class ChallengeDto {
   late double? closeRadiusF;
   late String? linkedEventId;
   late int? timerLength;
+  late String? scheduledStartTime;
+  late String? scheduledEndTime;
 }
 
 class RequestChallengeDataDto {
@@ -2085,6 +2119,7 @@ class ClubSubmissionDto {
     if (longitude != null) {
       fields['longitude'] = longitude;
     }
+    fields['category'] = category!.name;
     if (address != null) {
       fields['address'] = address;
     }
@@ -2107,6 +2142,7 @@ class ClubSubmissionDto {
     location = fields["location"];
     latitude = fields.containsKey('latitude') ? (fields["latitude"]) : null;
     longitude = fields.containsKey('longitude') ? (fields["longitude"]) : null;
+    category = ClubSubmissionCategoryDto.values.byName(fields['category']);
     address = fields.containsKey('address') ? (fields["address"]) : null;
     imageUrl = fields.containsKey('imageUrl') ? (fields["imageUrl"]) : null;
     registrationLink = fields.containsKey('registrationLink')
@@ -2124,6 +2160,7 @@ class ClubSubmissionDto {
     location = other.location;
     latitude = other.latitude == null ? latitude : other.latitude;
     longitude = other.longitude == null ? longitude : other.longitude;
+    category = other.category;
     address = other.address == null ? address : other.address;
     imageUrl = other.imageUrl == null ? imageUrl : other.imageUrl;
     registrationLink = other.registrationLink == null
@@ -2141,6 +2178,7 @@ class ClubSubmissionDto {
     required this.location,
     this.latitude,
     this.longitude,
+    required this.category,
     this.address,
     this.imageUrl,
     this.registrationLink,
@@ -2155,6 +2193,7 @@ class ClubSubmissionDto {
   late String location;
   late int? latitude;
   late int? longitude;
+  late ClubSubmissionCategoryDto category;
   late String? address;
   late String? imageUrl;
   late String? registrationLink;
@@ -2571,6 +2610,9 @@ class PrevChallengeDto {
     if (failed != null) {
       fields['failed'] = failed;
     }
+    if (dateExpired != null) {
+      fields['dateExpired'] = dateExpired;
+    }
     return fields;
   }
 
@@ -2582,6 +2624,8 @@ class PrevChallengeDto {
         : null;
     dateCompleted = fields["dateCompleted"];
     failed = fields.containsKey('failed') ? (fields["failed"]) : null;
+    dateExpired =
+        fields.containsKey('dateExpired') ? (fields["dateExpired"]) : null;
   }
 
   void partialUpdate(PrevChallengeDto other) {
@@ -2591,6 +2635,7 @@ class PrevChallengeDto {
         other.extensionsUsed == null ? extensionsUsed : other.extensionsUsed;
     dateCompleted = other.dateCompleted;
     failed = other.failed == null ? failed : other.failed;
+    dateExpired = other.dateExpired == null ? dateExpired : other.dateExpired;
   }
 
   PrevChallengeDto({
@@ -2599,6 +2644,7 @@ class PrevChallengeDto {
     this.extensionsUsed,
     required this.dateCompleted,
     this.failed,
+    this.dateExpired,
   });
 
   late String challengeId;
@@ -2606,6 +2652,7 @@ class PrevChallengeDto {
   late int? extensionsUsed;
   late String dateCompleted;
   late bool? failed;
+  late bool? dateExpired;
 }
 
 class EventTrackerDto {

--- a/game/lib/api/game_server_api.dart
+++ b/game/lib/api/game_server_api.dart
@@ -65,11 +65,11 @@ class GameServerApi {
   Future<int?> requestAchievementData(RequestAchievementDataDto dto) async =>
       await _invokeWithRefresh("requestAchievementData", dto.toJson());
 
-  Future<dynamic?> requestAchievementTrackerData(
+  Future<int?> requestAchievementTrackerData(
           RequestAchievementTrackerDataDto dto) async =>
       await _invokeWithRefresh("requestAchievementTrackerData", dto.toJson());
 
-  Future<dynamic?> updateAchievementData(UpdateAchievementDataDto dto) async =>
+  Future<String?> updateAchievementData(UpdateAchievementDataDto dto) async =>
       await _invokeWithRefresh("updateAchievementData", dto.toJson());
 
   Future<int?> requestBearItems(RequestBearItemsDto dto) async =>
@@ -90,7 +90,7 @@ class GameServerApi {
   Future<int?> requestAllBearItems(RequestAllBearItemsDto dto) async =>
       await _invokeWithRefresh("requestAllBearItems", dto.toJson());
 
-  Future<dynamic?> updateBearItemData(UpdateBearItemDataDto dto) async =>
+  Future<String?> updateBearItemData(UpdateBearItemDataDto dto) async =>
       await _invokeWithRefresh("updateBearItemData", dto.toJson());
 
   Future<int?> requestCampusEvents(RequestCampusEventsDto dto) async =>
@@ -103,10 +103,10 @@ class GameServerApi {
   Future<int?> requestAllCampusEvents(RequestCampusEventsDto dto) async =>
       await _invokeWithRefresh("requestAllCampusEvents", dto.toJson());
 
-  Future<dynamic?> createCampusEvent(UpsertCampusEventDto dto) async =>
+  Future<String?> createCampusEvent(UpsertCampusEventDto dto) async =>
       await _invokeWithRefresh("createCampusEvent", dto.toJson());
 
-  Future<dynamic?> updateCampusEvent(UpsertCampusEventDto dto) async =>
+  Future<String?> updateCampusEvent(UpsertCampusEventDto dto) async =>
       await _invokeWithRefresh("updateCampusEvent", dto.toJson());
 
   Future<bool?> deleteCampusEvent(DeleteCampusEventDto dto) async =>
@@ -128,10 +128,10 @@ class GameServerApi {
   Future<int?> requestChallengeData(RequestChallengeDataDto dto) async =>
       await _invokeWithRefresh("requestChallengeData", dto.toJson());
 
-  Future<dynamic?> completedChallenge(CompletedChallengeDto dto) async =>
+  Future<String?> completedChallenge(CompletedChallengeDto dto) async =>
       await _invokeWithRefresh("completedChallenge", dto.toJson());
 
-  Future<dynamic?> updateChallengeData(UpdateChallengeDataDto dto) async =>
+  Future<String?> updateChallengeData(UpdateChallengeDataDto dto) async =>
       await _invokeWithRefresh("updateChallengeData", dto.toJson());
 
   Future<bool?> checkInWithLocation(LocationCheckInDto dto) async =>
@@ -153,14 +153,13 @@ class GameServerApi {
   Future<int?> requestEventLeaderData(RequestEventLeaderDataDto dto) async =>
       await _invokeWithRefresh("requestEventLeaderData", dto.toJson());
 
-  Future<dynamic?> requestEventTrackerData(
-          RequestEventTrackerDataDto dto) async =>
+  Future<int?> requestEventTrackerData(RequestEventTrackerDataDto dto) async =>
       await _invokeWithRefresh("requestEventTrackerData", dto.toJson());
 
   Future<bool?> useEventTrackerHint(UseEventTrackerHintDto dto) async =>
       await _invokeWithRefresh("useEventTrackerHint", dto.toJson());
 
-  Future<dynamic?> updateEventData(UpdateEventDataDto dto) async =>
+  Future<String?> updateEventData(UpdateEventDataDto dto) async =>
       await _invokeWithRefresh("updateEventData", dto.toJson());
 
   Future<dynamic?> triggerEventSync(TriggerEventSyncDto dto) async =>
@@ -202,12 +201,10 @@ class GameServerApi {
   Future<bool?> removeFcmToken(Map<String, dynamic> dto) async =>
       await _invokeWithRefresh("removeFcmToken", dto);
 
-  Future<dynamic?> requestOrganizationData(
-          RequestOrganizationDataDto dto) async =>
+  Future<int?> requestOrganizationData(RequestOrganizationDataDto dto) async =>
       await _invokeWithRefresh("requestOrganizationData", dto.toJson());
 
-  Future<dynamic?> updateOrganizationData(
-          UpdateOrganizationDataDto dto) async =>
+  Future<String?> updateOrganizationData(UpdateOrganizationDataDto dto) async =>
       await _invokeWithRefresh("updateOrganizationData", dto.toJson());
 
   Future<bool?> requestQuizQuestion(RequestQuizQuestionDto dto) async =>
@@ -255,7 +252,7 @@ class GameServerApi {
   Future<bool?> banUser(BanUserDto dto) async =>
       await _invokeWithRefresh("banUser", dto.toJson());
 
-  Future<dynamic?> addManager(AddManagerDto dto) async =>
+  Future<String?> addManager(AddManagerDto dto) async =>
       await _invokeWithRefresh("addManager", dto.toJson());
 
   Future<bool?> joinOrganization(JoinOrganizationDto dto) async =>

--- a/game/lib/journeys/journey_challenge_list_sheet.dart
+++ b/game/lib/journeys/journey_challenge_list_sheet.dart
@@ -14,6 +14,7 @@ import 'package:game/navigation_page/bottom_navbar.dart';
 import 'package:game/utils/utility_functions.dart';
 import 'package:game/widget/cached_image.dart';
 import 'package:geolocator/geolocator.dart';
+import 'package:intl/intl.dart';
 import 'package:provider/provider.dart';
 import 'dart:async';
 
@@ -182,8 +183,29 @@ class _JourneyChallengeListSheetState extends State<JourneyChallengeListSheet> {
     final totalChallenges = event?.challenges?.length ?? 0;
     final remaining = availableChallenges.length;
 
+    // Partition available challenges into available now vs upcoming
+    final now = DateTime.now();
+    final availableNow = <ChallengeDto>[];
+    final upcoming = <ChallengeDto>[];
+
+    for (final challenge in availableChallenges) {
+      final startStr = challenge.scheduledStartTime;
+      final endStr = challenge.scheduledEndTime;
+      final start = startStr != null ? DateTime.tryParse(startStr) : null;
+      final end = endStr != null ? DateTime.tryParse(endStr) : null;
+
+      if (start != null && now.isBefore(start)) {
+        upcoming.add(challenge);
+      } else if (end != null && now.isAfter(end)) {
+        // Should already be auto-completed by server, skip
+        continue;
+      } else {
+        availableNow.add(challenge);
+      }
+    }
+
     // Sort available challenges by distance
-    final sortedAvailable = List<ChallengeDto>.from(availableChallenges);
+    final sortedAvailable = List<ChallengeDto>.from(availableNow);
     sortedAvailable.sort((a, b) {
       final distA = _distanceTo(a);
       final distB = _distanceTo(b);
@@ -368,6 +390,59 @@ class _JourneyChallengeListSheetState extends State<JourneyChallengeListSheet> {
                                 ),
                               ),
                             ],
+                            // Upcoming section
+                            if (upcoming.isNotEmpty) ...[
+                              Padding(
+                                padding:
+                                    const EdgeInsets.only(top: 12, bottom: 4),
+                                child: Text(
+                                  'Upcoming',
+                                  style: TextStyle(
+                                    fontFamily: 'Poppins',
+                                    fontSize: 14,
+                                    fontWeight: FontWeight.bold,
+                                    color: AppColors.grayText,
+                                  ),
+                                ),
+                              ),
+                              ...upcoming.map(
+                                (challenge) => _JourneyChallengeCard(
+                                  challenge: challenge,
+                                  isCompleted: false,
+                                  isUpcoming: true,
+                                  walkingTime:
+                                      _walkingTime(_distanceTo(challenge)),
+                                  onTap: () {
+                                    final startStr =
+                                        challenge.scheduledStartTime;
+                                    final start = startStr != null
+                                        ? DateTime.tryParse(startStr)
+                                        : null;
+                                    final formatted = start != null
+                                        ? DateFormat.yMMMd()
+                                            .add_jm()
+                                            .format(start.toLocal())
+                                        : 'a future date';
+                                    showDialog(
+                                      context: context,
+                                      builder: (_) => AlertDialog(
+                                        title: Text('Not Yet Available'),
+                                        content: Text(
+                                          'This challenge is available on $formatted. Come back then!',
+                                        ),
+                                        actions: [
+                                          TextButton(
+                                            onPressed: () =>
+                                                Navigator.pop(context),
+                                            child: Text('OK'),
+                                          ),
+                                        ],
+                                      ),
+                                    );
+                                  },
+                                ),
+                              ),
+                            ],
                             // Completed section
                             if (completedChallenges.isNotEmpty) ...[
                               Padding(
@@ -386,6 +461,8 @@ class _JourneyChallengeListSheetState extends State<JourneyChallengeListSheet> {
                               ...completedChallenges.map(
                                 (challenge) {
                                   final prev = prevChallengeMap[challenge.id];
+                                  final isDateExpired =
+                                      prev?.dateExpired == true;
                                   final totalPts = challenge.points ?? 0;
                                   int earned;
                                   if (prev?.failed == true) {
@@ -406,6 +483,7 @@ class _JourneyChallengeListSheetState extends State<JourneyChallengeListSheet> {
                                   return _JourneyChallengeCard(
                                     challenge: challenge,
                                     isCompleted: true,
+                                    isDateExpired: isDateExpired,
                                     walkingTime:
                                         _walkingTime(_distanceTo(challenge)),
                                     earnedPoints: earned,
@@ -429,6 +507,8 @@ class _JourneyChallengeListSheetState extends State<JourneyChallengeListSheet> {
 class _JourneyChallengeCard extends StatelessWidget {
   final ChallengeDto challenge;
   final bool isCompleted;
+  final bool isUpcoming;
+  final bool isDateExpired;
   final String walkingTime;
   final int? earnedPoints;
   final VoidCallback? onTap;
@@ -437,132 +517,234 @@ class _JourneyChallengeCard extends StatelessWidget {
     required this.challenge,
     required this.isCompleted,
     required this.walkingTime,
+    this.isUpcoming = false,
+    this.isDateExpired = false,
     this.earnedPoints,
     this.onTap,
   });
 
+  bool get _isTodayOnly {
+    final startStr = challenge.scheduledStartTime;
+    final endStr = challenge.scheduledEndTime;
+    if (startStr == null && endStr == null) return false;
+    final start = startStr != null ? DateTime.tryParse(startStr) : null;
+    final end = endStr != null ? DateTime.tryParse(endStr) : null;
+    final now = DateTime.now();
+    final today = DateTime(now.year, now.month, now.day);
+    final tomorrow = today.add(Duration(days: 1));
+    final isAfterStart = start == null || !now.isBefore(start);
+    final isBeforeEnd = end == null || now.isBefore(end);
+    final endsToday = end != null && end.isBefore(tomorrow);
+    return isAfterStart && isBeforeEnd && endsToday;
+  }
+
   @override
   Widget build(BuildContext context) {
+    final isGrayed = isUpcoming || isCompleted;
+    final cardColor = isGrayed ? AppColors.lightGray : Colors.white;
+
     return GestureDetector(
       onTap: onTap,
-      child: Container(
-        margin: const EdgeInsets.only(bottom: 8),
-        padding: const EdgeInsets.all(8),
-        decoration: BoxDecoration(
-          color: Colors.white,
-          borderRadius: BorderRadius.circular(8),
-          boxShadow: [
-            BoxShadow(
-              color: AppColors.black10,
-              offset: Offset(0, 2),
-              blurRadius: 6,
-            ),
-          ],
-        ),
-        child: Row(
-          children: [
-            // Left content
-            Expanded(
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  // Name + walking time row
-                  Row(
-                    children: [
-                      Flexible(
-                        child: Text(
-                          challenge.name ?? '',
-                          overflow: TextOverflow.ellipsis,
+      child: Opacity(
+        opacity: isGrayed ? 0.6 : 1.0,
+        child: Container(
+          margin: const EdgeInsets.only(bottom: 8),
+          padding: const EdgeInsets.all(8),
+          decoration: BoxDecoration(
+            color: cardColor,
+            borderRadius: BorderRadius.circular(8),
+            boxShadow: [
+              BoxShadow(
+                color: AppColors.black10,
+                offset: Offset(0, 2),
+                blurRadius: 6,
+              ),
+            ],
+          ),
+          child: Row(
+            children: [
+              // Left content
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    // Name + walking time row + badges
+                    Row(
+                      children: [
+                        Flexible(
+                          child: Text(
+                            challenge.name ?? '',
+                            overflow: TextOverflow.ellipsis,
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 16,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.darkGrayText,
+                            ),
+                          ),
+                        ),
+                        Padding(
+                          padding: const EdgeInsets.symmetric(horizontal: 8),
+                          child: Container(
+                            width: 4,
+                            height: 4,
+                            decoration: BoxDecoration(
+                              color: AppColors.darkGrayText,
+                              shape: BoxShape.circle,
+                            ),
+                          ),
+                        ),
+                        if (isUpcoming) ...[
+                          Icon(
+                            Icons.calendar_today,
+                            size: 16,
+                            color: AppColors.grayText,
+                          ),
+                          SizedBox(width: 4),
+                          Text(
+                            _formatScheduledDate(),
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.grayText,
+                            ),
+                          ),
+                        ] else ...[
+                          Icon(
+                            Icons.directions_walk,
+                            size: 18,
+                            color: AppColors.darkGrayText,
+                          ),
+                          SizedBox(width: 2),
+                          Text(
+                            walkingTime,
+                            style: TextStyle(
+                              fontFamily: 'Poppins',
+                              fontSize: 12,
+                              fontWeight: FontWeight.bold,
+                              color: AppColors.darkGrayText,
+                            ),
+                          ),
+                        ],
+                      ],
+                    ),
+                    SizedBox(height: 8),
+                    // Badges row
+                    if (_isTodayOnly || isDateExpired)
+                      Padding(
+                        padding: const EdgeInsets.only(bottom: 4),
+                        child: Row(
+                          children: [
+                            if (_isTodayOnly)
+                              Container(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 2,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: AppColors.orange,
+                                  borderRadius: BorderRadius.circular(20),
+                                ),
+                                child: Text(
+                                  'Today Only',
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 11,
+                                    fontFamily: 'Poppins',
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ),
+                            if (isDateExpired)
+                              Container(
+                                padding: EdgeInsets.symmetric(
+                                  horizontal: 8,
+                                  vertical: 2,
+                                ),
+                                decoration: BoxDecoration(
+                                  color: AppColors.mediumGray,
+                                  borderRadius: BorderRadius.circular(20),
+                                ),
+                                child: Text(
+                                  'Expired',
+                                  style: TextStyle(
+                                    color: Colors.white,
+                                    fontSize: 11,
+                                    fontFamily: 'Poppins',
+                                    fontWeight: FontWeight.w500,
+                                  ),
+                                ),
+                              ),
+                          ],
+                        ),
+                      ),
+                    // Description
+                    Text(
+                      challenge.description ?? '',
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                      style: TextStyle(
+                        fontFamily: 'Poppins',
+                        fontSize: 12,
+                        fontWeight:
+                            isCompleted ? FontWeight.bold : FontWeight.normal,
+                        color: AppColors.grayText,
+                      ),
+                    ),
+                    SizedBox(height: 12),
+                    // Points
+                    Row(
+                      children: [
+                        SvgPicture.asset(
+                          'assets/icons/bearcoins.svg',
+                          width: 20,
+                          height: 20,
+                        ),
+                        SizedBox(width: 5),
+                        Text(
+                          isDateExpired
+                              ? 'Expired — 0 PTS'
+                              : isCompleted
+                                  ? '${earnedPoints ?? challenge.points ?? 0} PTS / ${challenge.points ?? 0} PTS'
+                                  : '${challenge.points ?? 0} PTS',
                           style: TextStyle(
                             fontFamily: 'Poppins',
-                            fontSize: 16,
+                            fontSize: 12,
                             fontWeight: FontWeight.bold,
-                            color: AppColors.darkGrayText,
+                            color: isDateExpired
+                                ? AppColors.mediumGray
+                                : AppColors.gold,
                           ),
                         ),
-                      ),
-                      Padding(
-                        padding: const EdgeInsets.symmetric(horizontal: 8),
-                        child: Container(
-                          width: 4,
-                          height: 4,
-                          decoration: BoxDecoration(
-                            color: AppColors.darkGrayText,
-                            shape: BoxShape.circle,
-                          ),
-                        ),
-                      ),
-                      Icon(
-                        Icons.directions_walk,
-                        size: 18,
-                        color: AppColors.darkGrayText,
-                      ),
-                      SizedBox(width: 2),
-                      Text(
-                        walkingTime,
-                        style: TextStyle(
-                          fontFamily: 'Poppins',
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                          color: AppColors.darkGrayText,
-                        ),
-                      ),
-                    ],
-                  ),
-                  SizedBox(height: 8),
-                  // Description
-                  Text(
-                    challenge.description ?? '',
-                    maxLines: 2,
-                    overflow: TextOverflow.ellipsis,
-                    style: TextStyle(
-                      fontFamily: 'Poppins',
-                      fontSize: 12,
-                      fontWeight:
-                          isCompleted ? FontWeight.bold : FontWeight.normal,
-                      color: AppColors.grayText,
+                      ],
                     ),
-                  ),
-                  SizedBox(height: 12),
-                  // Points
-                  Row(
-                    children: [
-                      SvgPicture.asset(
-                        'assets/icons/bearcoins.svg',
-                        width: 20,
-                        height: 20,
-                      ),
-                      SizedBox(width: 5),
-                      Text(
-                        isCompleted
-                            ? '${earnedPoints ?? challenge.points ?? 0} PTS / ${challenge.points ?? 0} PTS'
-                            : '${challenge.points ?? 0} PTS',
-                        style: TextStyle(
-                          fontFamily: 'Poppins',
-                          fontSize: 12,
-                          fontWeight: FontWeight.bold,
-                          color: AppColors.gold,
-                        ),
-                      ),
-                    ],
-                  ),
-                ],
+                  ],
+                ),
               ),
-            ),
-            SizedBox(width: 8),
-            // Thumbnail
-            ClipRRect(
-              borderRadius: BorderRadius.circular(8),
-              child: AppCachedImage(
-                imageUrl: challenge.imageUrl ?? '',
-                width: 82,
-                height: 81,
+              SizedBox(width: 8),
+              // Thumbnail
+              ClipRRect(
+                borderRadius: BorderRadius.circular(8),
+                child: AppCachedImage(
+                  imageUrl: challenge.imageUrl ?? '',
+                  width: 82,
+                  height: 81,
+                ),
               ),
-            ),
-          ],
+            ],
+          ),
         ),
       ),
     );
+  }
+
+  String _formatScheduledDate() {
+    final startStr = challenge.scheduledStartTime;
+    if (startStr == null) return '';
+    final start = DateTime.tryParse(startStr);
+    if (start == null) return '';
+    return DateFormat.MMMd().format(start.toLocal());
   }
 }
 

--- a/server/prisma/migrations/20260414212655_add_scheduled_time_to_challenge/migration.sql
+++ b/server/prisma/migrations/20260414212655_add_scheduled_time_to_challenge/migration.sql
@@ -1,0 +1,6 @@
+-- AlterTable
+ALTER TABLE "Challenge" ADD COLUMN     "scheduledEndTime" TIMESTAMP(3),
+ADD COLUMN     "scheduledStartTime" TIMESTAMP(3);
+
+-- AlterTable
+ALTER TABLE "PrevChallenge" ADD COLUMN     "dateExpired" BOOLEAN NOT NULL DEFAULT false;

--- a/server/prisma/schema.prisma
+++ b/server/prisma/schema.prisma
@@ -148,7 +148,9 @@ model Challenge {
   longitude      Float
   awardingRadius Float
   closeRadius    Float
-  timerLength    Int?
+  timerLength         Int?
+  scheduledStartTime  DateTime?
+  scheduledEndTime    DateTime?
   completions    PrevChallenge[]
   activeTrackers EventTracker[]
   QuizQuestion   QuizQuestion[]
@@ -224,6 +226,7 @@ model PrevChallenge {
   extensionsUsed Int          @default(0)
   timestamp      DateTime     @default(now())
   failed         Boolean      @default(false) // True if challenge was failed due to timer expiration
+  dateExpired    Boolean      @default(false) // True if auto-completed because time window passed
 }
 
 model Organization {

--- a/server/src/challenge/challenge.dto.ts
+++ b/server/src/challenge/challenge.dto.ts
@@ -28,6 +28,8 @@ export interface ChallengeDto {
   closeRadiusF?: number;
   linkedEventId?: string;
   timerLength?: number;
+  scheduledStartTime?: string;
+  scheduledEndTime?: string;
 }
 
 /** DTO for requestChallengeData */

--- a/server/src/challenge/challenge.service.ts
+++ b/server/src/challenge/challenge.service.ts
@@ -136,12 +136,78 @@ export class ChallengeService {
   }
 
   /**
+   * Auto-complete challenges whose scheduled end time has passed.
+   * Creates PrevChallenge records with failed=true, dateExpired=true, 0 points.
+   * Advances curChallengeId if it was pointing to an expired challenge.
+   */
+  private async autoCompleteExpiredScheduledChallenges(
+    user: User,
+    evTracker: EventTracker,
+  ) {
+    const now = new Date();
+
+    const expiredChallenges = await this.prisma.challenge.findMany({
+      where: {
+        linkedEventId: evTracker.eventId,
+        scheduledEndTime: { lt: now },
+        completions: { none: { userId: user.id } },
+      },
+    });
+
+    if (expiredChallenges.length === 0) return;
+
+    for (const challenge of expiredChallenges) {
+      await this.prisma.prevChallenge.create({
+        data: {
+          userId: user.id,
+          challengeId: challenge.id,
+          trackerId: evTracker.id,
+          hintsUsed: 0,
+          failed: true,
+          dateExpired: true,
+        },
+      });
+    }
+
+    // If the current challenge was expired, advance to next available
+    if (
+      evTracker.curChallengeId &&
+      expiredChallenges.some(c => c.id === evTracker.curChallengeId)
+    ) {
+      const nextAvailable = await this.prisma.challenge.findFirst({
+        where: {
+          linkedEventId: evTracker.eventId,
+          completions: { none: { userId: user.id } },
+        },
+        orderBy: { eventIndex: 'asc' },
+      });
+
+      await this.prisma.eventTracker.update({
+        where: { id: evTracker.id },
+        data: {
+          curChallengeId: nextAvailable?.id ?? null,
+          hintsUsed: 0,
+        },
+      });
+    }
+
+    // Emit tracker update so the client sees the new PrevChallenge records
+    const updatedTracker = await this.prisma.eventTracker.findUniqueOrThrow({
+      where: { id: evTracker.id },
+    });
+    await this.eventService.emitUpdateEventTracker(updatedTracker, user);
+  }
+
+  /**
    * Get all available (uncompleted) challenges in the user's current journey.
    * Returns challenges sorted by eventIndex for consistent ordering.
    */
   async getAvailableChallenges(user: User): Promise<Challenge[]> {
     const evTracker =
       await this.eventService.getCurrentEventTrackerForUser(user);
+
+    // Auto-complete any challenges whose scheduled window has passed
+    await this.autoCompleteExpiredScheduledChallenges(user, evTracker);
 
     return await this.prisma.challenge.findMany({
       where: {
@@ -176,6 +242,15 @@ export class ChallengeService {
 
     if (!challenge) {
       return null; // Challenge not found or belongs to different event
+    }
+
+    // Reject if challenge is outside its scheduled time window
+    const now = new Date();
+    if (
+      (challenge.scheduledStartTime && now < challenge.scheduledStartTime) ||
+      (challenge.scheduledEndTime && now > challenge.scheduledEndTime)
+    ) {
+      return null;
     }
 
     const isCompleted =
@@ -248,6 +323,20 @@ export class ChallengeService {
       await this.eventService.getCurrentEventTrackerForUser(user);
 
     if (!eventTracker.curChallengeId) return null;
+
+    // Reject if current challenge is outside its scheduled time window
+    const curChal = await this.prisma.challenge.findFirst({
+      where: { id: eventTracker.curChallengeId },
+    });
+    if (curChal) {
+      const now = new Date();
+      if (
+        (curChal.scheduledStartTime && now < curChal.scheduledStartTime) ||
+        (curChal.scheduledEndTime && now > curChal.scheduledEndTime)
+      ) {
+        return null;
+      }
+    }
 
     const alreadyDone =
       (await this.prisma.prevChallenge.count({
@@ -568,6 +657,8 @@ export class ChallengeService {
       closeRadiusF: ch.closeRadius,
       linkedEventId: ch.linkedEventId!,
       timerLength: ch.timerLength ?? undefined,
+      scheduledStartTime: ch.scheduledStartTime?.toISOString() ?? undefined,
+      scheduledEndTime: ch.scheduledEndTime?.toISOString() ?? undefined,
     };
   }
 
@@ -608,6 +699,12 @@ export class ChallengeService {
         awardingRadius: challenge.awardingRadiusF,
         closeRadius: challenge.closeRadiusF,
         timerLength: challenge.timerLength ?? null,
+        scheduledStartTime: challenge.scheduledStartTime
+          ? new Date(challenge.scheduledStartTime)
+          : null,
+        scheduledEndTime: challenge.scheduledEndTime
+          ? new Date(challenge.scheduledEndTime)
+          : null,
       };
 
       const data = await this.abilityFactory.filterInaccessible(
@@ -647,6 +744,12 @@ export class ChallengeService {
         eventIndex: (maxIndexChallenge._max.eventIndex ?? -1) + 1,
         linkedEventId: challenge.linkedEventId,
         timerLength: challenge.timerLength ?? null,
+        scheduledStartTime: challenge.scheduledStartTime
+          ? new Date(challenge.scheduledStartTime)
+          : null,
+        scheduledEndTime: challenge.scheduledEndTime
+          ? new Date(challenge.scheduledEndTime)
+          : null,
       };
 
       chal = await this.prisma.challenge.create({

--- a/server/src/event/event.dto.ts
+++ b/server/src/event/event.dto.ts
@@ -111,6 +111,7 @@ export interface PrevChallengeDto {
   extensionsUsed?: number;
   dateCompleted: string;
   failed?: boolean; // True if challenge was failed due to timer expiration
+  dateExpired?: boolean;
 }
 
 /** DTO for event tracker in updateEventTrackerData */

--- a/server/src/event/event.service.ts
+++ b/server/src/event/event.service.ts
@@ -420,6 +420,7 @@ export class EventService {
         extensionsUsed: pc.extensionsUsed ?? 0, // Default to 0 for backwards compatibility
         dateCompleted: pc.timestamp.toUTCString(),
         failed: pc.failed, // True if challenge was failed due to timer expiration
+        dateExpired: pc.dateExpired,
       })),
     };
   }


### PR DESCRIPTION
### Summary

This PR adds date-restricted challenges — challenges within journeys that can only be completed during a specific time window (e.g., Slope Day, Dragon Day).

- [x] Added `scheduledStartTime` and `scheduledEndTime` fields to Challenge model
- [x] Added `dateExpired` field to PrevChallenge model to track auto-completed expired challenges
- [x] Server guards on `setCurrentChallenge` and `completeChallenge` to reject out-of-window attempts
- [x] Lazy auto-completion: when a user opens their challenge list, any challenges past their scheduled end time are automatically marked as failed with 0 points
- [x] Admin UI: new checkbox + datetime picker fields for setting scheduled start/end times on challenges
- [x] Admin UI: challenge cards display scheduled date range when set
- [x] Mobile UI: challenges partitioned into "Nearest to you", "Upcoming", and "Completed" sections
- [x] Mobile UI: upcoming challenges appear grayed out with calendar icon + date; tapping shows availability popup
- [x] Mobile UI: completed and upcoming challenges render with reduced opacity
- [x] Mobile UI: "Today Only" orange badge for challenges whose window ends today
- [x] Mobile UI: "Expired" gray badge + gray points text for date-expired completions

### Test Plan

Tested and verified:
- Admin: create a challenge with a scheduled start/end time, verify form saves and loads correctly
- Admin: verify scheduled date range displays on challenge card
- Mobile: verify challenges with a future start time appear in "Upcoming" section, grayed out
- Mobile: tap an upcoming challenge → confirm popup shows the availability date
- Mobile: verify challenges with a window including today show "Today Only" badge
- Mobile: set a challenge with a past end time, open the journey → confirm it auto-completes with 0 points and shows "Expired" badge in the completed section
- Mobile: verify completed section appears after auto-completion (tracker update emitted)

### Notes

- Auto-completion is lazy: it runs when `getAvailableChallenges` is called, not on a cron. This means expired challenges won't appear as completed until the user opens the challenge list