### PR TITLE
Add react key as a docker build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN npm install --legacy-peer-deps
 
 WORKDIR /app/admin
 COPY admin .
+ARG REACT_APP_GOOGLE_MAPS_API_KEY
+ENV REACT_APP_GOOGLE_MAPS_API_KEY=$REACT_APP_GOOGLE_MAPS_API_KEY
 RUN npm run build
 
 WORKDIR /app/server

--- a/heroku.yml
+++ b/heroku.yml
@@ -2,5 +2,8 @@ setup:
   addons:
     - plan: heroku-postgresql
 build:
+  config:
+    REACT_APP_GOOGLE_MAPS_API_KEY:
+      description: "Google Maps API key for admin dashboard"
   docker:
     web: Dockerfile


### PR DESCRIPTION
### Summary <!-- Required -->

Pass in a Docker build arg for the admin google maps key so it’s available during npm run build