### PR TITLE
Add EventModel for flutter Campusevent access

### DIFF
--- a/game/lib/main.dart
+++ b/game/lib/main.dart
@@ -11,6 +11,7 @@ import 'package:game/api/geopoint.dart';
 import 'package:game/api/notification_service.dart';
 import 'package:game/loading_page/loading_page.dart';
 import 'package:game/model/achievement_model.dart';
+import 'package:game/model/campus_event_model.dart';
 import 'package:device_preview/device_preview.dart';
 import 'package:game/model/onboarding_model.dart';
 import 'package:game/model/timer_model.dart';
@@ -161,6 +162,10 @@ class MyApp extends StatelessWidget {
         ),
         ChangeNotifierProvider(create: (_) => TimerModel(client), lazy: false),
         ChangeNotifierProvider(create: (_) => QuizModel(client), lazy: false),
+        ChangeNotifierProvider(
+          create: (_) => CampusEventModel(client),
+          lazy: false,
+        ),
       ],
       child: GameWidget(
         child: MaterialApp(

--- a/game/lib/model/campus_event_model.dart
+++ b/game/lib/model/campus_event_model.dart
@@ -1,0 +1,82 @@
+import 'package:flutter/foundation.dart';
+import 'package:game/api/game_api.dart';
+import 'package:game/api/game_client_dto.dart';
+
+class CampusEventModel extends ChangeNotifier {
+  final Map<String, CampusEventDto> _eventsById = {};
+  CampusEventListDto? _currentList;
+  final ApiClient _client;
+
+  CampusEventModel(ApiClient client) : _client = client {
+    client.clientApi.updateCampusEventDataStream.listen((event) {
+      if (event.deleted) {
+        _eventsById.remove(event.event.id);
+      } else {
+        _eventsById[event.event.id] = event.event;
+      }
+      notifyListeners();
+    });
+
+    client.clientApi.campusEventListStream.listen((event) {
+      _currentList = event.list;
+      for (final campusEvent in event.list.events) {
+        _eventsById[campusEvent.id] = campusEvent;
+      }
+      notifyListeners();
+    });
+
+    client.clientApi.connectedStream.listen((event) {
+      _eventsById.clear();
+      _currentList = null;
+      notifyListeners();
+    });
+  }
+
+  CampusEventDto? getCampusEventById(String id) {
+    final event = _eventsById[id];
+    if (event == null) {
+      _client.serverApi?.requestCampusEventDetails(
+        RequestCampusEventDetailsDto(eventId: id),
+      );
+    }
+    return event;
+  }
+
+  CampusEventListDto? get currentList => _currentList;
+
+  List<CampusEventDto> get allCachedEvents => _eventsById.values.toList();
+
+  void requestCampusEvents({
+    int page = 1,
+    int limit = 20,
+    String? dateFrom,
+    String? dateTo,
+    List<RequestCampusEventsCategoriesDto>? categories,
+    String? search,
+    bool? featured,
+  }) {
+    _client.serverApi?.requestCampusEvents(
+      RequestCampusEventsDto(
+        page: page,
+        limit: limit,
+        dateFrom: dateFrom,
+        dateTo: dateTo,
+        categories: categories,
+        search: search,
+        featured: featured,
+      ),
+    );
+  }
+
+  void rsvpCampusEvent(String campusEventId) {
+    _client.serverApi?.rsvpCampusEvent(
+      RsvpCampusEventDto(eventId: campusEventId),
+    );
+  }
+
+  void unRsvpCampusEvent(String campusEventId) {
+    _client.serverApi?.unRsvpCampusEvent(
+      UnRsvpCampusEventDto(eventId: campusEventId),
+    );
+  }
+}


### PR DESCRIPTION
### Summary
Add Flutter frontend model for CampusEvent feature
- [x] Created `CampusEventModel` (ChangeNotifier) with in-memory cache, WebSocket stream listeners, and player-facing methods (fetch, RSVP/un-RSVP)
- [x] Registered `CampusEventModel` as a provider in `main.dart`

### Notes
- Only player-facing methods are included (no admin create/update/delete). Admin methods can be added if needed.