### PR TITLE
Admin Dashboard Campus Event Creation

### DIFF
--- a/admin/package-lock.json
+++ b/admin/package-lock.json
@@ -84,7 +84,6 @@
       "version": "7.21.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
       "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
@@ -976,7 +975,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
       "integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.18.6"
       },
@@ -1538,7 +1536,6 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.0.tgz",
       "integrity": "sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -2380,7 +2377,6 @@
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
       "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
       "hasInstallScript": true,
-      "peer": true,
       "dependencies": {
         "@fortawesome/fontawesome-common-types": "6.4.0"
       },
@@ -3549,7 +3545,8 @@
     "node_modules/@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.0",
@@ -3949,7 +3946,6 @@
       "version": "5.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
       "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
-      "peer": true,
       "dependencies": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.57.0",
@@ -4001,7 +3997,6 @@
       "version": "5.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
       "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.57.0",
         "@typescript-eslint/types": "5.57.0",
@@ -4338,7 +4333,6 @@
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
       "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4446,7 +4440,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -5202,7 +5195,6 @@
           "url": "https://tidelift.com/funding/github/npm/browserslist"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -5911,7 +5903,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -6965,7 +6956,6 @@
       "version": "8.36.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
       "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -7358,7 +7348,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -9439,7 +9428,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -10961,7 +10949,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -11749,7 +11736,6 @@
           "url": "https://tidelift.com/funding/github/npm/postcss"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -12808,7 +12794,6 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
       "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -13005,7 +12990,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -13169,7 +13153,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -13240,7 +13223,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -13275,7 +13257,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -13740,7 +13721,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -14540,7 +14520,6 @@
       "version": "5.3.9",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.9.tgz",
       "integrity": "sha512-Aj3kb13B75DQBo2oRwRa/APdB5rSmwUfN5exyarpX+x/tlM/rwZA2vVk2vQgVSP6WKaZJHWwiFrzgHt+CLtB4A==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -15130,7 +15109,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -15180,7 +15158,6 @@
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
       "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -15453,7 +15430,6 @@
       "version": "5.76.3",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
       "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -15522,7 +15498,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -15572,7 +15547,6 @@
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz",
       "integrity": "sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -15631,7 +15605,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -15983,7 +15956,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16376,7 +16348,6 @@
       "version": "7.21.3",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.21.3.tgz",
       "integrity": "sha512-qIJONzoa/qiHghnm0l1n4i/6IIziDpzqc36FBs4pzMhDUraHqponwJLiAKm1hGLP3OSB/TVNz6rMwVGpwxxySw==",
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.18.6",
@@ -16999,7 +16970,6 @@
       "version": "7.18.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.18.6.tgz",
       "integrity": "sha512-LUbR+KNTBWCUAqRG9ex5Gnzu2IOkt8jRJbHHXFT9q+L9zm7M/QQbEqXyw1n1pohYvOyWC8CjeyjrSaIwiYjK7A==",
-      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.18.6"
       }
@@ -17345,7 +17315,6 @@
       "version": "7.21.0",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.21.0.tgz",
       "integrity": "sha512-6OAWljMvQrZjR2DaNhVfRz6dkCAVV+ymcLUmaf8bccGOHn2v5rHJK3tTpij0BuhdYWP4LLaqj5lwcdlpAAPuvg==",
-      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.18.6",
         "@babel/helper-module-imports": "^7.18.6",
@@ -17885,7 +17854,6 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-svg-core/-/fontawesome-svg-core-6.4.0.tgz",
       "integrity": "sha512-Bertv8xOiVELz5raB2FlXDPKt+m94MQ3JgDfsVbrqNpLU9+UE2E18GKjLKw+d3XbeYPqg1pzyQKGsrzbw+pPaw==",
-      "peer": true,
       "requires": {
         "@fortawesome/fontawesome-common-types": "6.4.0"
       }
@@ -18714,7 +18682,8 @@
     "@types/aria-query": {
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
-      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw=="
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "peer": true
     },
     "@types/babel__core": {
       "version": "7.20.0",
@@ -19109,7 +19078,6 @@
       "version": "5.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.57.0.tgz",
       "integrity": "sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==",
-      "peer": true,
       "requires": {
         "@eslint-community/regexpp": "^4.4.0",
         "@typescript-eslint/scope-manager": "5.57.0",
@@ -19135,7 +19103,6 @@
       "version": "5.57.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.57.0.tgz",
       "integrity": "sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==",
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.57.0",
         "@typescript-eslint/types": "5.57.0",
@@ -19388,8 +19355,7 @@
     "acorn": {
       "version": "8.8.2",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
-      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
-      "peer": true
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw=="
     },
     "acorn-globals": {
       "version": "6.0.0",
@@ -19467,7 +19433,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -20020,7 +19985,6 @@
       "version": "4.21.5",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.21.5.tgz",
       "integrity": "sha512-tUkiguQGW7S3IhB7N+c2MV/HZPSCPAAiYBZXLsBhFB/PCy6ZKKsZrmBayHV9fdGV/ARIfJ14NkxKzRDjvp7L6w==",
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001449",
         "electron-to-chromium": "^1.4.284",
@@ -20515,7 +20479,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -21306,7 +21269,6 @@
       "version": "8.36.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.36.0.tgz",
       "integrity": "sha512-Y956lmS7vDqomxlaaQAHVmeb4tNMp2FWIvU/RnU5BD3IKMD/MJPr76xdyr68P8tV1iNMvN2mRK0yy3c+UjL+bw==",
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.4.0",
@@ -21620,7 +21582,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -23089,7 +23050,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-      "peer": true,
       "requires": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -24258,7 +24218,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -24809,7 +24768,6 @@
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
       "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -25393,7 +25351,6 @@
       "version": "6.0.11",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.11.tgz",
       "integrity": "sha512-zbARubNdogI9j7WY4nQJBiNqQf3sLS3wCP4WfOidu+p28LofJqDH1tcXypGrcmMHhDk2t9wGhCsYe/+szLTy1g==",
-      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -25533,7 +25490,6 @@
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
       "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
@@ -25652,7 +25608,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -25713,7 +25668,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -25741,8 +25695,7 @@
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
       "version": "5.3.4",
@@ -26081,7 +26034,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -26675,7 +26627,6 @@
       "version": "5.3.9",
       "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.9.tgz",
       "integrity": "sha512-Aj3kb13B75DQBo2oRwRa/APdB5rSmwUfN5exyarpX+x/tlM/rwZA2vVk2vQgVSP6WKaZJHWwiFrzgHt+CLtB4A==",
-      "peer": true,
       "requires": {
         "@babel/helper-module-imports": "^7.0.0",
         "@babel/traverse": "^7.4.5",
@@ -27118,8 +27069,7 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -27156,8 +27106,7 @@
     "typescript": {
       "version": "4.9.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
-      "peer": true
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g=="
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -27354,7 +27303,6 @@
       "version": "5.76.3",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.76.3.tgz",
       "integrity": "sha512-18Qv7uGPU8b2vqGeEEObnfICyw2g39CHlDEK4I7NK13LOur1d0HGmGNKGT58Eluwddpn3oEejwvBPoP4M7/KSA==",
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^0.0.51",
@@ -27419,7 +27367,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -27457,7 +27404,6 @@
       "version": "4.13.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.13.1.tgz",
       "integrity": "sha512-5tWg00bnWbYgkN+pd5yISQKDejRBYGEw15RaEEslH+zdbNDxxaZvEAO2WulaSaFKb5n3YG8JXsGaDsut1D0xdA==",
-      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -27495,7 +27441,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -27748,7 +27693,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/admin/src/App.tsx
+++ b/admin/src/App.tsx
@@ -7,6 +7,7 @@ import { Users } from './components/Users';
 import { Notifications } from './components/Notifications';
 import { Feedback } from './components/Feedback';
 import { BearItems } from './components/BearItems';
+import { CampusEvents } from './components/CampusEvents';
 
 import {
   AppBar,
@@ -34,6 +35,7 @@ import {
   faBell,
   faComment,
   faPaw,
+  faCalendarDays,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
@@ -106,6 +108,12 @@ const routes = [
     element: <BearItems />,
     icon: faPaw,
     name: 'Bear Items',
+  },
+  {
+    path: '/campus-events',
+    element: <CampusEvents />,
+    icon: faCalendarDays,
+    name: 'Campus Events',
   },
 ];
 

--- a/admin/src/all.dto.ts
+++ b/admin/src/all.dto.ts
@@ -77,6 +77,13 @@ export enum CampusEventCheckInMethodDto {
   EITHER = 'EITHER',
 }
 
+export enum CampusEventApprovalStatusDto {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  ARCHIVED = 'ARCHIVED',
+}
+
 export enum RequestCampusEventsCategoriesDto {
   SOCIAL = 'SOCIAL',
   CULTURAL = 'CULTURAL',
@@ -111,6 +118,13 @@ export enum UpsertCampusEventCheckInMethodDto {
   LOCATION = 'LOCATION',
   QR_CODE = 'QR_CODE',
   EITHER = 'EITHER',
+}
+
+export enum UpsertCampusEventApprovalStatusDto {
+  PENDING = 'PENDING',
+  APPROVED = 'APPROVED',
+  REJECTED = 'REJECTED',
+  ARCHIVED = 'ARCHIVED',
 }
 
 export enum ChallengeLocationDto {
@@ -362,15 +376,19 @@ export interface CampusEventDto {
   address?: string;
   latitude: number;
   longitude: number;
+  checkInRadius: number;
   categories: CampusEventCategoriesDto[];
   tags: string[];
   source: CampusEventSourceDto;
   externalUrl?: string;
   organizerName?: string;
+  organizerEmail?: string;
   registrationUrl?: string;
   checkInMethod: CampusEventCheckInMethodDto;
   pointsForAttendance: number;
   featured: boolean;
+  approvalStatus: CampusEventApprovalStatusDto;
+  rejectionReason?: string;
   attendanceCount: number;
   rsvpCount: number;
 }
@@ -422,6 +440,8 @@ export interface UpsertCampusEventDto {
   pointsForAttendance?: number;
   featured?: boolean;
   registrationUrl?: string;
+  approvalStatus?: UpsertCampusEventApprovalStatusDto;
+  rejectionReason?: string;
 }
 
 export interface DeleteCampusEventDto {

--- a/admin/src/components/CampusEvents.tsx
+++ b/admin/src/components/CampusEvents.tsx
@@ -9,6 +9,7 @@ import {
   UpsertCampusEventDto,
   UpsertCampusEventSourceDto,
 } from '../all.dto';
+import { AlertModal } from './AlertModal';
 import { DeleteModal } from './DeleteModal';
 import {
   DateEntryForm,
@@ -149,6 +150,17 @@ function makeCampusEventForm(): EntryForm[] {
       helpText: 'Required when Approval Status is REJECTED.',
     },
   ];
+}
+
+function validateCampusEventForm(form: EntryForm[]): string | null {
+  const approvalForm = form[18] as OptionEntryForm;
+  const status = approvalForm.options[approvalForm.value];
+  if (status !== 'REJECTED') return null;
+  const reason = ((form[19] as FreeEntryForm).value ?? '').trim();
+  if (!reason) {
+    return 'Enter a rejection reason when Approval Status is REJECTED.';
+  }
+  return null;
 }
 
 function eventToForm(ev: CampusEventDto): EntryForm[] {
@@ -326,6 +338,8 @@ export function CampusEvents() {
   const [query, setQuery] = useState('');
   const [page, setPage] = useState(1);
   const [form, setForm] = useState<EntryForm[]>(() => makeCampusEventForm());
+  const [alertOpen, setAlertOpen] = useState(false);
+  const [alertMessage, setAlertMessage] = useState('');
 
   const handleRadiusChange = (radius: number) => {
     setForm(prev => {
@@ -387,11 +401,22 @@ export function CampusEvents() {
 
   return (
     <>
+      <AlertModal
+        description={alertMessage}
+        isOpen={alertOpen}
+        onClose={() => setAlertOpen(false)}
+      />
       <EntryModal
         title="Create Campus Event"
         isOpen={createOpen}
         entryButtonText="CREATE"
         onEntry={async () => {
+          const err = validateCampusEventForm(form);
+          if (err) {
+            setAlertMessage(err);
+            setAlertOpen(true);
+            return;
+          }
           const dto = formToUpsert(form);
           await serverData.createCampusEvent(dto);
           setCreateOpen(false);
@@ -407,6 +432,12 @@ export function CampusEvents() {
         isOpen={editOpen}
         entryButtonText="SAVE"
         onEntry={async () => {
+          const err = validateCampusEventForm(form);
+          if (err) {
+            setAlertMessage(err);
+            setAlertOpen(true);
+            return;
+          }
           const dto = formToUpsert(form, currentId);
           await serverData.updateCampusEvent(dto);
           setEditOpen(false);

--- a/admin/src/components/CampusEvents.tsx
+++ b/admin/src/components/CampusEvents.tsx
@@ -1,0 +1,502 @@
+import { useContext, useEffect, useMemo, useState } from 'react';
+import { compareTwoStrings } from 'string-similarity';
+import styled from 'styled-components';
+import {
+  CampusEventCheckInMethodDto,
+  CampusEventDto,
+  UpsertCampusEventCategoriesDto,
+  UpsertCampusEventCheckInMethodDto,
+  UpsertCampusEventDto,
+  UpsertCampusEventSourceDto,
+} from '../all.dto';
+import { DeleteModal } from './DeleteModal';
+import {
+  DateEntryForm,
+  EntryForm,
+  EntryModal,
+  FreeEntryForm,
+  MapEntryForm,
+  NumberEntryForm,
+  OptionEntryForm,
+} from './EntryModal';
+import { HButton } from './HButton';
+import {
+  CenterText,
+  ListCardBody,
+  ListCardBox,
+  ListCardButtons,
+  ListCardDescription,
+  ListCardTitle,
+} from './ListCard';
+import { SearchBar } from './SearchBar';
+import { ServerDataContext } from './ServerData';
+
+const ActionRow = styled.div`
+  display: flex;
+  gap: 8px;
+  justify-content: center;
+  margin-bottom: 12px;
+`;
+
+const PageIndicator = styled.div`
+  align-self: center;
+  font-weight: bold;
+`;
+
+const categories = [
+  'SOCIAL',
+  'CULTURAL',
+  'ATHLETIC',
+  'WELLNESS',
+  'ACADEMIC',
+  'ARTS',
+  'CAREER',
+  'COMMUNITY',
+  'OTHER',
+] as const;
+
+const approvalStatuses = ['APPROVED', 'REJECTED', 'ARCHIVED'] as const;
+
+function parseCsv(value: string) {
+  return value
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+}
+
+function makeCampusEventForm(): EntryForm[] {
+  const start = new Date(Date.now() + 60 * 60 * 1000);
+  const end = new Date(Date.now() + 2 * 60 * 60 * 1000);
+  return [
+    { name: 'Title', characterLimit: 256, value: '' },
+    {
+      name: 'Description',
+      characterLimit: 4096,
+      value: '',
+      multiline: true,
+    },
+    {
+      name: 'Image URL',
+      characterLimit: 2048,
+      value: '',
+      helpText: 'Optional. Leave blank for no image.',
+    },
+    { name: 'Start Time', date: start },
+    { name: 'End Time', date: end },
+    { name: 'All-day', options: ['No', 'Yes'], value: 0 },
+    { name: 'Location Name', characterLimit: 256, value: '' },
+    {
+      name: 'Address',
+      characterLimit: 512,
+      value: '',
+      helpText: 'Optional. Can be blank if location name is sufficient.',
+    },
+    {
+      name: 'Map Location',
+      latitude: 42.4534,
+      longitude: -76.4735,
+      awardingRadiusF: 100,
+    },
+    { name: 'Check-in Radius (meters)', min: 1, max: 5000, value: 100 },
+    {
+      name: 'Categories (comma-separated)',
+      characterLimit: 512,
+      value: 'OTHER',
+      helpText: `Required. Options: ${categories.join(', ')}`,
+    },
+    {
+      name: 'Tags (comma-separated)',
+      characterLimit: 512,
+      value: '',
+      helpText: 'Optional.',
+    },
+    {
+      name: 'Organizer Name',
+      characterLimit: 256,
+      value: '',
+      helpText: 'Optional.',
+    },
+    {
+      name: 'Organizer Email',
+      characterLimit: 256,
+      value: '',
+      helpText: 'Optional.',
+    },
+    {
+      name: 'Check-in Method',
+      options: ['LOCATION', 'QR_CODE', 'EITHER'],
+      value: 2,
+    },
+    { name: 'Points for Attendance', min: 0, max: 1000, value: 10 },
+    { name: 'Featured', options: ['No', 'Yes'], value: 0 },
+    {
+      name: 'Registration URL',
+      characterLimit: 2048,
+      value: '',
+      helpText: 'Optional.',
+    },
+    {
+      name: 'Approval Status',
+      options: [...approvalStatuses],
+      value: 0,
+    },
+    {
+      name: 'Rejection Reason',
+      characterLimit: 1024,
+      value: '',
+      multiline: true,
+      hidden: true,
+      helpText: 'Required when Approval Status is REJECTED.',
+    },
+  ];
+}
+
+function eventToForm(ev: CampusEventDto): EntryForm[] {
+  const base = makeCampusEventForm();
+  const categoryValue = (ev.categories ?? []).join(',') || 'OTHER';
+  const tagsValue = (ev.tags ?? []).join(',');
+  const approvalIndex = approvalStatuses.indexOf(
+    (ev.approvalStatus as (typeof approvalStatuses)[number]) ?? 'APPROVED',
+  );
+
+  (base[0] as FreeEntryForm).value = ev.title ?? '';
+  (base[1] as FreeEntryForm).value = ev.description ?? '';
+  (base[2] as FreeEntryForm).value = ev.imageUrl ?? '';
+  (base[3] as DateEntryForm).date = new Date(ev.startTime);
+  (base[4] as DateEntryForm).date = new Date(ev.endTime);
+  (base[5] as OptionEntryForm).value = ev.allDay ? 1 : 0;
+  (base[6] as FreeEntryForm).value = ev.locationName ?? '';
+  (base[7] as FreeEntryForm).value = ev.address ?? '';
+  (base[8] as MapEntryForm).latitude = ev.latitude ?? 0;
+  (base[8] as MapEntryForm).longitude = ev.longitude ?? 0;
+  (base[8] as MapEntryForm).awardingRadiusF = ev.checkInRadius ?? 100;
+  (base[9] as NumberEntryForm).value = ev.checkInRadius ?? 100;
+  (base[10] as FreeEntryForm).value = categoryValue;
+  (base[11] as FreeEntryForm).value = tagsValue;
+  (base[12] as FreeEntryForm).value = ev.organizerName ?? '';
+  (base[13] as FreeEntryForm).value = ev.organizerEmail ?? '';
+  (base[14] as OptionEntryForm).value =
+    ev.checkInMethod === CampusEventCheckInMethodDto.LOCATION
+      ? 0
+      : ev.checkInMethod === CampusEventCheckInMethodDto.QR_CODE
+        ? 1
+        : 2;
+  (base[15] as NumberEntryForm).value = ev.pointsForAttendance ?? 10;
+  (base[16] as OptionEntryForm).value = ev.featured ? 1 : 0;
+  (base[17] as FreeEntryForm).value = ev.registrationUrl ?? '';
+  (base[18] as OptionEntryForm).value = Math.max(0, approvalIndex);
+  (base[19] as FreeEntryForm).value = ev.rejectionReason ?? '';
+  (base[19] as FreeEntryForm).hidden = ev.approvalStatus !== 'REJECTED';
+
+  return base;
+}
+
+function formToUpsert(form: EntryForm[], id?: string): UpsertCampusEventDto {
+  const title = (form[0] as FreeEntryForm).value.trim();
+  const description = (form[1] as FreeEntryForm).value.trim();
+  const imageUrl = (form[2] as FreeEntryForm).value.trim();
+  const startTime = (form[3] as DateEntryForm).date.toISOString();
+  const endTime = (form[4] as DateEntryForm).date.toISOString();
+  const allDay = (form[5] as OptionEntryForm).value === 1;
+  const locationName = (form[6] as FreeEntryForm).value.trim();
+  const address = (form[7] as FreeEntryForm).value.trim();
+  const map = form[8] as MapEntryForm;
+  const checkInRadius = (form[9] as NumberEntryForm).value;
+  const categoriesInput = (form[10] as FreeEntryForm).value;
+  const tagsInput = (form[11] as FreeEntryForm).value;
+  const organizerName = (form[12] as FreeEntryForm).value.trim();
+  const organizerEmail = (form[13] as FreeEntryForm).value.trim();
+  const checkInMethod = (form[14] as OptionEntryForm).options[
+    (form[14] as OptionEntryForm).value
+  ] as UpsertCampusEventCheckInMethodDto;
+  const pointsForAttendance = (form[15] as NumberEntryForm).value;
+  const featured = (form[16] as OptionEntryForm).value === 1;
+  const registrationUrl = (form[17] as FreeEntryForm).value.trim();
+  const approvalStatus = (form[18] as OptionEntryForm).options[
+    (form[18] as OptionEntryForm).value
+  ] as UpsertCampusEventDto['approvalStatus'];
+  const rejectionReason = (form[19] as FreeEntryForm).value.trim();
+
+  const parsedCategories = parseCsv(categoriesInput)
+    .map(c => c.toUpperCase())
+    .filter(c => (categories as readonly string[]).includes(c))
+    .map(c => c as UpsertCampusEventCategoriesDto);
+
+  return {
+    id,
+    title,
+    description,
+    imageUrl: imageUrl || undefined,
+    startTime,
+    endTime,
+    allDay,
+    locationName,
+    address: address || undefined,
+    latitude: map.latitude,
+    longitude: map.longitude,
+    checkInRadius,
+    categories: (parsedCategories.length ? parsedCategories : ['OTHER']).map(
+      v => v as UpsertCampusEventCategoriesDto,
+    ),
+    tags: parseCsv(tagsInput),
+    source: UpsertCampusEventSourceDto.ADMIN_CREATED,
+    externalUrl: undefined,
+    organizerName: organizerName || undefined,
+    organizerEmail: organizerEmail || undefined,
+    checkInMethod,
+    pointsForAttendance,
+    featured,
+    registrationUrl: registrationUrl || undefined,
+    approvalStatus,
+    rejectionReason:
+      approvalStatus === 'REJECTED' ? rejectionReason : undefined,
+  };
+}
+
+function CampusEventCard(props: {
+  event: CampusEventDto;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  const start = new Date(props.event.startTime).toLocaleString();
+  const end = new Date(props.event.endTime).toLocaleString();
+
+  return (
+    <ListCardBox>
+      <ListCardTitle>{props.event.title}</ListCardTitle>
+      <ListCardDescription>{props.event.description}</ListCardDescription>
+      <ListCardBody>
+        Status: <b>{props.event.approvalStatus}</b>
+        {props.event.approvalStatus === 'REJECTED' &&
+          props.event.rejectionReason && (
+            <>
+              <br />
+              Rejection Reason: <b>{props.event.rejectionReason}</b>
+            </>
+          )}
+        <br />
+        When: <b>{start}</b> → <b>{end}</b>
+        <br />
+        All-day: <b>{props.event.allDay ? 'Yes' : 'No'}</b>
+        <br />
+        Where: <b>{props.event.locationName}</b>
+        {props.event.address ? (
+          <>
+            <br />
+            Address: <b>{props.event.address}</b>
+          </>
+        ) : null}
+        <br />
+        Coordinates: <b>{props.event.latitude}</b>,{' '}
+        <b>{props.event.longitude}</b>
+        <br />
+        Check-in Radius: <b>{props.event.checkInRadius}m</b>
+        <br />
+        Check-in Method: <b>{props.event.checkInMethod}</b>
+        <br />
+        Categories: <b>{(props.event.categories ?? []).join(', ')}</b>
+        <br />
+        Tags: <b>{(props.event.tags ?? []).join(', ') || 'None'}</b>
+        <br />
+        Points: <b>{props.event.pointsForAttendance}</b>
+        <br />
+        Featured: <b>{props.event.featured ? 'Yes' : 'No'}</b>
+        <br />
+        RSVP: <b>{props.event.rsvpCount}</b> • Attendance:{' '}
+        <b>{props.event.attendanceCount}</b>
+      </ListCardBody>
+      <ListCardButtons>
+        <HButton onClick={props.onDelete}>DELETE</HButton>
+        <HButton onClick={props.onEdit} float="right">
+          EDIT
+        </HButton>
+      </ListCardButtons>
+    </ListCardBox>
+  );
+}
+
+export function CampusEvents() {
+  const serverData = useContext(ServerDataContext);
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [editOpen, setEditOpen] = useState(false);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+
+  const [currentId, setCurrentId] = useState('');
+  const [query, setQuery] = useState('');
+  const [page, setPage] = useState(1);
+  const [form, setForm] = useState<EntryForm[]>(() => makeCampusEventForm());
+
+  const handleRadiusChange = (radius: number) => {
+    setForm(prev => {
+      const next = [...prev];
+      (next[9] as NumberEntryForm).value = radius;
+      next[8] = {
+        ...(next[8] as MapEntryForm),
+        awardingRadiusF: radius,
+      };
+      return next;
+    });
+  };
+
+  const handleApprovalStatusChange = (status: string) => {
+    setForm(prev => {
+      const next = [...prev];
+      (next[19] as FreeEntryForm).hidden = status !== 'REJECTED';
+      return next;
+    });
+  };
+
+  const currentList = serverData.campusEventList;
+  const totalPages = currentList?.totalPages ?? 1;
+
+  useEffect(() => {
+    serverData.requestCampusEvents({
+      page,
+      limit: 50,
+      search: query || undefined,
+    });
+  }, [page, query]);
+
+  const visibleEvents = useMemo(() => {
+    const fromList = serverData.campusEventList?.events ?? [];
+    const base =
+      fromList.length > 0
+        ? fromList
+        : Array.from(serverData.campusEvents.values());
+    const filtered = base.filter(ev => {
+      if (!query.trim()) return true;
+      const q = query.toLowerCase();
+      return (
+        (ev.title ?? '').toLowerCase().includes(q) ||
+        (ev.description ?? '').toLowerCase().includes(q) ||
+        (ev.locationName ?? '').toLowerCase().includes(q)
+      );
+    });
+
+    return filtered.sort(
+      (a, b) =>
+        compareTwoStrings(b.title ?? '', query) -
+          compareTwoStrings(a.title ?? '', query) +
+          compareTwoStrings(b.description ?? '', query) -
+          compareTwoStrings(a.description ?? '', query) +
+          compareTwoStrings(b.locationName ?? '', query) -
+          compareTwoStrings(a.locationName ?? '', query) || 0,
+    );
+  }, [serverData.campusEventList, serverData.campusEvents, query]);
+
+  return (
+    <>
+      <EntryModal
+        title="Create Campus Event"
+        isOpen={createOpen}
+        entryButtonText="CREATE"
+        onEntry={async () => {
+          const dto = formToUpsert(form);
+          await serverData.createCampusEvent(dto);
+          setCreateOpen(false);
+        }}
+        onCancel={() => setCreateOpen(false)}
+        form={form}
+        onRadiusChange={(awardingRadius: number) =>
+          handleRadiusChange(awardingRadius)
+        }
+      />
+      <EntryModal
+        title="Edit Campus Event"
+        isOpen={editOpen}
+        entryButtonText="SAVE"
+        onEntry={async () => {
+          const dto = formToUpsert(form, currentId);
+          await serverData.updateCampusEvent(dto);
+          setEditOpen(false);
+        }}
+        onCancel={() => setEditOpen(false)}
+        form={form}
+        onRadiusChange={(awardingRadius: number) =>
+          handleRadiusChange(awardingRadius)
+        }
+      />
+      <DeleteModal
+        objectName={
+          serverData.campusEvents.get(currentId)?.title ?? 'this event'
+        }
+        isOpen={deleteOpen}
+        onClose={() => setDeleteOpen(false)}
+        onDelete={async () => {
+          await serverData.deleteCampusEvent(currentId);
+          setDeleteOpen(false);
+        }}
+      />
+
+      <SearchBar
+        onCreate={() => {
+          const f = makeCampusEventForm();
+          (f[19] as FreeEntryForm).hidden = true;
+          (f[9] as NumberEntryForm).onChange = v => handleRadiusChange(v);
+          (f[18] as OptionEntryForm).onChange = idx =>
+            handleApprovalStatusChange(
+              (f[18] as OptionEntryForm).options[idx] ?? 'APPROVED',
+            );
+          setForm(f);
+          setCreateOpen(true);
+        }}
+        onSearch={q => {
+          setPage(1);
+          setQuery(q);
+        }}
+      />
+
+      <ActionRow>
+        <HButton
+          onClick={() => setPage(p => Math.max(1, p - 1))}
+          disabled={page <= 1}
+        >
+          Prev
+        </HButton>
+        <PageIndicator>
+          Page {page} / {totalPages}
+        </PageIndicator>
+        <HButton
+          onClick={() => setPage(p => Math.min(totalPages, p + 1))}
+          disabled={page >= totalPages}
+        >
+          Next
+        </HButton>
+      </ActionRow>
+
+      {visibleEvents.length === 0 ? (
+        <CenterText>No campus events found</CenterText>
+      ) : null}
+
+      {visibleEvents.map(ev => (
+        <CampusEventCard
+          key={ev.id}
+          event={ev}
+          onEdit={() => {
+            const fresh = serverData.campusEvents.get(ev.id);
+            if (!fresh) return;
+            setCurrentId(ev.id);
+            const f = eventToForm(fresh);
+            (f[9] as NumberEntryForm).onChange = v => handleRadiusChange(v);
+            (f[18] as OptionEntryForm).onChange = idx =>
+              handleApprovalStatusChange(
+                (f[18] as OptionEntryForm).options[idx] ?? 'APPROVED',
+              );
+            handleApprovalStatusChange(
+              (f[18] as OptionEntryForm).options[
+                (f[18] as OptionEntryForm).value
+              ] ?? 'APPROVED',
+            );
+            setForm(f);
+            setEditOpen(true);
+          }}
+          onDelete={() => {
+            setCurrentId(ev.id);
+            setDeleteOpen(true);
+          }}
+        />
+      ))}
+    </>
+  );
+}

--- a/admin/src/components/CampusEvents.tsx
+++ b/admin/src/components/CampusEvents.tsx
@@ -1,3 +1,14 @@
+
+/**
+ * Campus Events page on the admin dashboard
+ *
+ * Gets campus events from `ServerDataContext` using`requestCampusEvents` → `campusEventList`, 
+ * plus `campusEvents` map and `updateCampusEventData` broadcasts).
+ *
+ * Allows admins to create/edit campus-event fields with location, title, description, 
+ * approval status, and other fields. 
+ * If an event is REJECTED, a rejection reason is required.
+ */
 import { useContext, useEffect, useMemo, useState } from 'react';
 import { compareTwoStrings } from 'string-similarity';
 import styled from 'styled-components';

--- a/admin/src/components/EntryModal.tsx
+++ b/admin/src/components/EntryModal.tsx
@@ -19,6 +19,8 @@ export type OptionEntryForm = {
   name: string;
   value: number;
   options: string[];
+  hidden?: boolean;
+  onChange?: (value: number) => void;
 };
 
 export type FreeEntryForm = {
@@ -27,6 +29,7 @@ export type FreeEntryForm = {
   characterLimit: number;
   multiline?: boolean;
   helpText?: string;
+  hidden?: boolean;  // for rejection reason of a campus event
 };
 
 export type NumberEntryForm = {
@@ -34,6 +37,8 @@ export type NumberEntryForm = {
   value: number;
   min: number;
   max: number;
+  hidden?: boolean;
+  onChange?: (value: number) => void;
 };
 
 export type MapEntryForm = {
@@ -42,11 +47,13 @@ export type MapEntryForm = {
   longitude: number;
   awardingRadiusF?: number;
   closeRadiusF?: number;
+  hidden?: boolean;
 };
 
 export type DateEntryForm = {
   name: string;
   date: Date;
+  hidden?: boolean;
 };
 
 export type CheckboxNumberEntryForm = {
@@ -56,6 +63,7 @@ export type CheckboxNumberEntryForm = {
   min: number;
   max: number;
   numberLabel: string;
+  hidden?: boolean;
 };
 
 export type AnswersEntryForm = {
@@ -63,12 +71,14 @@ export type AnswersEntryForm = {
   answers: Array<{ text: string; isCorrect: boolean }>;
   minAnswers: number;
   maxAnswers: number;
+  hidden?: boolean;
 };
 
 export type CheckboxDateEntryForm = {
   name: string;
   checked: boolean;
   date: Date;
+  hidden?: boolean;
 };
 
 export type OptionWithCustomEntryForm = {
@@ -77,6 +87,7 @@ export type OptionWithCustomEntryForm = {
   options: string[];
   customValue: string;
   customOptionLabel: string;
+  hidden?: boolean;
 };
 
 export type EntryForm =
@@ -134,11 +145,12 @@ function OptionEntryFormBox(props: { form: OptionEntryForm }) {
       <EntrySelect
         name={props.form.name}
         value={val}
-        onChange={e =>
-          setVal(
-            props.form.options[(props.form.value = e.target.selectedIndex)],
-          )
-        }
+        onChange={e => { // show/hide campus event rejection reason
+          const next = e.target.selectedIndex;
+          props.form.value = next;
+          props.form.onChange?.(next);
+          setVal(props.form.options[next]);
+        }}
       >
         {props.form.options.map(val => (
           <option key={val} onSelect={() => console.log(val)}>
@@ -229,6 +241,7 @@ function NumberEntryFormBox(props: {
           const num = +e.target.value;
           setVal(e.target.value);
           props.form.value = num;
+          props.form.onChange?.(num); // update map circle radius for campus event
           props.onChange?.(num);
         }}
       />
@@ -786,6 +799,7 @@ export function EntryModal(props: {
       }}
     >
       {props.form.map(form => {
+        if ('hidden' in form && form.hidden) return null;
         if ('answers' in form) {
           return <AnswersEntryFormBox form={form} key={form.name} />;
         } else if ('customOptionLabel' in form) {

--- a/admin/src/components/HButton.tsx
+++ b/admin/src/components/HButton.tsx
@@ -1,6 +1,9 @@
 import styled, { css } from 'styled-components';
 
-export const HButton = styled.div<{ float?: 'left' | 'right' }>`
+export const HButton = styled.div<{ // support disabled boolean
+  float?: 'left' | 'right';
+  disabled?: boolean;
+}>`
   display: inline-block;
   height: 30px;
   user-select: none;
@@ -11,6 +14,13 @@ export const HButton = styled.div<{ float?: 'left' | 'right' }>`
   border-radius: 4px;
   font-weight: 500;
   text-align: center;
+
+  ${props =>
+    props.disabled &&
+    css`
+      opacity: 0.45;
+      pointer-events: none;
+    `}
 
   :hover {
     background-color: rgb(245, 245, 255);

--- a/admin/src/components/ServerData.tsx
+++ b/admin/src/components/ServerData.tsx
@@ -9,6 +9,10 @@ import {
 import {
   AdminBearItemDto,
   ChallengeDto,
+  CampusEventDto,
+  CampusEventListDto,
+  RequestCampusEventsDto,
+  UpsertCampusEventDto,
   UpdateErrorDto,
   EventDto,
   GroupDto,
@@ -24,6 +28,8 @@ import { ServerConnectionContext } from './ServerConnection';
 /**  object to store user data fetched from server */
 const defaultData = {
   events: new Map<string, EventDto>(),
+  campusEvents: new Map<string, CampusEventDto>(),
+  campusEventList: undefined as CampusEventListDto | undefined,
   achievements: new Map<string, AchievementDto>(),
   challenges: new Map<string, ChallengeDto>(),
   organizations: new Map<string, OrganizationDto>(),
@@ -37,6 +43,24 @@ const defaultData = {
   selectEvent(id: string) {},
   selectOrg(id: string) {},
   setAdminStatus(id: string, granted: boolean) {},
+  async requestCampusEvents(
+    request: RequestCampusEventsDto,
+  ): Promise<number | undefined> {
+    return undefined;
+  },
+  async createCampusEvent(
+    campusEvent: UpsertCampusEventDto,
+  ): Promise<string | undefined> {
+    return undefined;
+  },
+  async updateCampusEvent(
+    campusEvent: UpsertCampusEventDto,
+  ): Promise<string | undefined> {
+    return undefined;
+  },
+  async deleteCampusEvent(eventId: string): Promise<boolean | undefined> {
+    return undefined;
+  },
   async updateChallenge(challenge: ChallengeDto): Promise<string | undefined> {
     return undefined;
   },
@@ -146,6 +170,18 @@ export function ServerDataProvider(props: { children: ReactNode }) {
           return { ...prev, selectedOrg: id, selectedEvent: '' };
         });
       },
+      requestCampusEvents(request: RequestCampusEventsDto) {
+        return sock.requestAllCampusEvents(request);
+      },
+      createCampusEvent(campusEvent: UpsertCampusEventDto) {
+        return sock.createCampusEvent(campusEvent);
+      },
+      updateCampusEvent(campusEvent: UpsertCampusEventDto) {
+        return sock.updateCampusEvent(campusEvent);
+      },
+      deleteCampusEvent(eventId: string) {
+        return sock.deleteCampusEvent({ eventId });
+      },
       updateChallenge(challenge: ChallengeDto) {
         return sock.send('updateChallengeData', { challenge, deleted: false });
       },
@@ -244,6 +280,49 @@ export function ServerDataProvider(props: { children: ReactNode }) {
 
   /** Update defaultData object when ServerApi websocket receives a response */
   useEffect(() => {
+    sock.onCampusEventList(data => {
+      // get list of events for UI
+      setServerData(prev => {
+        const newCampusEvents = new Map(prev.campusEvents);
+        for (const ev of data.list.events ?? []) {
+          newCampusEvents.set(ev.id, ev);
+        }
+        return {
+          ...prev,
+          campusEvents: newCampusEvents,
+          campusEventList: data.list,
+        };
+      });
+    });
+    // update campus event list if when an event changes
+    sock.onUpdateCampusEventData(data => {
+      setServerData(prev => {
+        const newCampusEvents = new Map(prev.campusEvents);
+        if (data.deleted) {
+          newCampusEvents.delete(data.event.id);
+        } else {
+          newCampusEvents.set(
+            (data.event as CampusEventDto).id,
+            data.event as CampusEventDto,
+          );
+        }
+        const newCampusEventList =
+          prev.campusEventList === undefined
+            ? undefined
+            : {
+                ...prev.campusEventList,
+                events: prev.campusEventList.events
+                  .filter(ev => ev.id !== data.event.id)
+                  .concat(data.deleted ? [] : [data.event as CampusEventDto]),
+              };
+
+        return {
+          ...prev,
+          campusEvents: newCampusEvents,
+          campusEventList: newCampusEventList,
+        };
+      });
+    });
     sock.onUpdateAchievementData(data => {
       setServerData(prev => {
         const newAchievements = new Map(prev.achievements);

--- a/game/android/app/build.gradle
+++ b/game/android/app/build.gradle
@@ -43,7 +43,7 @@ android {
     defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId 'com.cornellgo.CornellGOApp'
-        minSdkVersion flutter.minSdkVersion
+        minSdkVersion 23
         targetSdkVersion 35
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/game/lib/api/game_client_dto.dart
+++ b/game/lib/api/game_client_dto.dart
@@ -77,6 +77,13 @@ enum CampusEventCheckInMethodDto {
   EITHER,
 }
 
+enum CampusEventApprovalStatusDto {
+  PENDING,
+  APPROVED,
+  REJECTED,
+  ARCHIVED,
+}
+
 enum RequestCampusEventsCategoriesDto {
   SOCIAL,
   CULTURAL,
@@ -111,6 +118,13 @@ enum UpsertCampusEventCheckInMethodDto {
   LOCATION,
   QR_CODE,
   EITHER,
+}
+
+enum UpsertCampusEventApprovalStatusDto {
+  PENDING,
+  APPROVED,
+  REJECTED,
+  ARCHIVED,
 }
 
 enum ChallengeLocationDto {
@@ -1081,6 +1095,7 @@ class CampusEventDto {
     }
     fields['latitude'] = latitude;
     fields['longitude'] = longitude;
+    fields['checkInRadius'] = checkInRadius;
     fields['categories'] =
         categories!.map<String>((dynamic val) => val!.name).toList();
     fields['tags'] = tags;
@@ -1091,12 +1106,19 @@ class CampusEventDto {
     if (organizerName != null) {
       fields['organizerName'] = organizerName;
     }
+    if (organizerEmail != null) {
+      fields['organizerEmail'] = organizerEmail;
+    }
     if (registrationUrl != null) {
       fields['registrationUrl'] = registrationUrl;
     }
     fields['checkInMethod'] = checkInMethod!.name;
     fields['pointsForAttendance'] = pointsForAttendance;
     fields['featured'] = featured;
+    fields['approvalStatus'] = approvalStatus!.name;
+    if (rejectionReason != null) {
+      fields['rejectionReason'] = rejectionReason;
+    }
     fields['attendanceCount'] = attendanceCount;
     fields['rsvpCount'] = rsvpCount;
     return fields;
@@ -1114,6 +1136,7 @@ class CampusEventDto {
     address = fields.containsKey('address') ? (fields["address"]) : null;
     latitude = fields["latitude"];
     longitude = fields["longitude"];
+    checkInRadius = fields["checkInRadius"];
     categories = fields["categories"]
         .map<CampusEventCategoriesDto>(
             (dynamic val) => CampusEventCategoriesDto.values.byName(val))
@@ -1124,6 +1147,9 @@ class CampusEventDto {
         fields.containsKey('externalUrl') ? (fields["externalUrl"]) : null;
     organizerName =
         fields.containsKey('organizerName') ? (fields["organizerName"]) : null;
+    organizerEmail = fields.containsKey('organizerEmail')
+        ? (fields["organizerEmail"])
+        : null;
     registrationUrl = fields.containsKey('registrationUrl')
         ? (fields["registrationUrl"])
         : null;
@@ -1131,6 +1157,11 @@ class CampusEventDto {
         CampusEventCheckInMethodDto.values.byName(fields['checkInMethod']);
     pointsForAttendance = fields["pointsForAttendance"];
     featured = fields["featured"];
+    approvalStatus =
+        CampusEventApprovalStatusDto.values.byName(fields['approvalStatus']);
+    rejectionReason = fields.containsKey('rejectionReason')
+        ? (fields["rejectionReason"])
+        : null;
     attendanceCount = fields["attendanceCount"];
     rsvpCount = fields["rsvpCount"];
   }
@@ -1147,17 +1178,23 @@ class CampusEventDto {
     address = other.address == null ? address : other.address;
     latitude = other.latitude;
     longitude = other.longitude;
+    checkInRadius = other.checkInRadius;
     categories = other.categories;
     tags = other.tags;
     source = other.source;
     externalUrl = other.externalUrl == null ? externalUrl : other.externalUrl;
     organizerName =
         other.organizerName == null ? organizerName : other.organizerName;
+    organizerEmail =
+        other.organizerEmail == null ? organizerEmail : other.organizerEmail;
     registrationUrl =
         other.registrationUrl == null ? registrationUrl : other.registrationUrl;
     checkInMethod = other.checkInMethod;
     pointsForAttendance = other.pointsForAttendance;
     featured = other.featured;
+    approvalStatus = other.approvalStatus;
+    rejectionReason =
+        other.rejectionReason == null ? rejectionReason : other.rejectionReason;
     attendanceCount = other.attendanceCount;
     rsvpCount = other.rsvpCount;
   }
@@ -1174,15 +1211,19 @@ class CampusEventDto {
     this.address,
     required this.latitude,
     required this.longitude,
+    required this.checkInRadius,
     required this.categories,
     required this.tags,
     required this.source,
     this.externalUrl,
     this.organizerName,
+    this.organizerEmail,
     this.registrationUrl,
     required this.checkInMethod,
     required this.pointsForAttendance,
     required this.featured,
+    required this.approvalStatus,
+    this.rejectionReason,
     required this.attendanceCount,
     required this.rsvpCount,
   });
@@ -1198,15 +1239,19 @@ class CampusEventDto {
   late String? address;
   late int latitude;
   late int longitude;
+  late int checkInRadius;
   late List<CampusEventCategoriesDto> categories;
   late List<String> tags;
   late CampusEventSourceDto source;
   late String? externalUrl;
   late String? organizerName;
+  late String? organizerEmail;
   late String? registrationUrl;
   late CampusEventCheckInMethodDto checkInMethod;
   late int pointsForAttendance;
   late bool featured;
+  late CampusEventApprovalStatusDto approvalStatus;
+  late String? rejectionReason;
   late int attendanceCount;
   late int rsvpCount;
 }
@@ -1403,6 +1448,12 @@ class UpsertCampusEventDto {
     if (registrationUrl != null) {
       fields['registrationUrl'] = registrationUrl;
     }
+    if (approvalStatus != null) {
+      fields['approvalStatus'] = approvalStatus!.name;
+    }
+    if (rejectionReason != null) {
+      fields['rejectionReason'] = rejectionReason;
+    }
     return fields;
   }
 
@@ -1448,6 +1499,13 @@ class UpsertCampusEventDto {
     registrationUrl = fields.containsKey('registrationUrl')
         ? (fields["registrationUrl"])
         : null;
+    approvalStatus = fields.containsKey('approvalStatus')
+        ? (UpsertCampusEventApprovalStatusDto.values
+            .byName(fields['approvalStatus']))
+        : null;
+    rejectionReason = fields.containsKey('rejectionReason')
+        ? (fields["rejectionReason"])
+        : null;
   }
 
   void partialUpdate(UpsertCampusEventDto other) {
@@ -1482,6 +1540,10 @@ class UpsertCampusEventDto {
     featured = other.featured == null ? featured : other.featured;
     registrationUrl =
         other.registrationUrl == null ? registrationUrl : other.registrationUrl;
+    approvalStatus =
+        other.approvalStatus == null ? approvalStatus : other.approvalStatus;
+    rejectionReason =
+        other.rejectionReason == null ? rejectionReason : other.rejectionReason;
   }
 
   UpsertCampusEventDto({
@@ -1509,6 +1571,8 @@ class UpsertCampusEventDto {
     this.pointsForAttendance,
     this.featured,
     this.registrationUrl,
+    this.approvalStatus,
+    this.rejectionReason,
   });
 
   late String? id;
@@ -1535,6 +1599,8 @@ class UpsertCampusEventDto {
   late int? pointsForAttendance;
   late bool? featured;
   late String? registrationUrl;
+  late UpsertCampusEventApprovalStatusDto? approvalStatus;
+  late String? rejectionReason;
 }
 
 class DeleteCampusEventDto {

--- a/game/pubspec.lock
+++ b/game/pubspec.lock
@@ -205,10 +205,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
+      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.3"
+    version: "1.3.2"
   ffi:
     dependency: transitive
     description:
@@ -705,26 +705,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "33e2e26bdd85a0112ec15400c8cbffea70d0f9c3407491f672a2fad47915e2de"
+      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
       url: "https://pub.dev"
     source: hosted
-    version: "11.0.2"
+    version: "10.0.8"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
+      sha256: f8b613e7e6a13ec79cfdc0e97638fddb3ab848452eff057653abd3edba760573
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.10"
+    version: "3.0.9"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
+      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.2"
+    version: "3.0.1"
   linkify:
     dependency: transitive
     description:
@@ -809,10 +809,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.16.0"
   mgrs_dart:
     dependency: transitive
     description:
@@ -1278,10 +1278,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: fb31f383e2ee25fbbfe06b40fe21e1e458d14080e3c67e7ba0acfde4df4e0bbd
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.4"
   timezone:
     dependency: transitive
     description:
@@ -1414,10 +1414,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.1.4"
   velocity_x:
     dependency: "direct main"
     description:
@@ -1499,5 +1499,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.8.0-0 <4.0.0"
+  dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.29.0"

--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -234,7 +234,6 @@
       "version": "7.28.4",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.3",
@@ -793,7 +792,6 @@
     "node_modules/@casl/ability": {
       "version": "6.7.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@ucast/mongo2js": "^1.3.0"
       },
@@ -1742,7 +1740,6 @@
       "version": "4.9.5",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1754,7 +1751,6 @@
     "node_modules/@nestjs/common": {
       "version": "10.4.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "file-type": "20.4.1",
         "iterare": "1.2.1",
@@ -1807,7 +1803,6 @@
       "version": "10.4.20",
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@nuxtjs/opencollective": "0.3.2",
         "fast-safe-stringify": "2.1.1",
@@ -1854,7 +1849,6 @@
     "node_modules/@nestjs/platform-express": {
       "version": "10.4.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "body-parser": "1.20.3",
         "cors": "2.8.5",
@@ -1874,7 +1868,6 @@
     "node_modules/@nestjs/platform-socket.io": {
       "version": "10.4.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "socket.io": "4.8.1",
         "tslib": "2.8.1"
@@ -2081,7 +2074,6 @@
     "node_modules/@nestjs/websockets": {
       "version": "10.4.20",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "iterare": "1.2.1",
         "object-hash": "3.0.0",
@@ -2176,7 +2168,6 @@
       "version": "5.10.2",
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "engines": {
         "node": ">=16.13"
       },
@@ -2579,7 +2570,6 @@
     "node_modules/@types/node": {
       "version": "20.19.11",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2758,7 +2748,6 @@
       "version": "4.33.0",
       "dev": true,
       "license": "BSD-2-Clause",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "4.33.0",
         "@typescript-eslint/types": "4.33.0",
@@ -3043,7 +3032,6 @@
     "node_modules/acorn": {
       "version": "8.15.0",
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3105,7 +3093,6 @@
       "version": "6.12.6",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -3759,7 +3746,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001733",
         "electron-to-chromium": "^1.5.199",
@@ -4983,7 +4969,6 @@
       "version": "7.32.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "7.12.11",
         "@eslint/eslintrc": "^0.4.3",
@@ -5342,7 +5327,6 @@
     "node_modules/express": {
       "version": "4.21.2",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "accepts": "~1.3.8",
         "array-flatten": "1.1.1",
@@ -7172,7 +7156,6 @@
       "version": "29.7.0",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -9185,7 +9168,6 @@
     "node_modules/pg": {
       "version": "8.16.3",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "pg-connection-string": "^2.9.1",
         "pg-pool": "^3.10.1",
@@ -9435,7 +9417,6 @@
       "version": "3.6.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -9499,7 +9480,6 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.10.2"
       },
@@ -9716,8 +9696,7 @@
     },
     "node_modules/reflect-metadata": {
       "version": "0.1.14",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",
@@ -9929,7 +9908,6 @@
     "node_modules/rxjs": {
       "version": "7.8.2",
       "license": "Apache-2.0",
-      "peer": true,
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -10925,7 +10903,6 @@
       "version": "8.17.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.3",
         "fast-uri": "^3.0.1",
@@ -11148,7 +11125,6 @@
       "version": "10.9.2",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -11438,7 +11414,6 @@
     "node_modules/typescript": {
       "version": "5.8.3",
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11635,7 +11610,6 @@
       "version": "5.82.1",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",

--- a/server/src/campus-event/campus-event.dto.ts
+++ b/server/src/campus-event/campus-event.dto.ts
@@ -41,15 +41,19 @@ export interface CampusEventDto {
   address?: string;
   latitude: number;
   longitude: number;
+  checkInRadius: number;
   categories: CampusEventCategoryDto[];
   tags: string[];
   source: EventSourceDto;
   externalUrl?: string;
   organizerName?: string;
+  organizerEmail?: string;
   registrationUrl?: string;
   checkInMethod: CheckInMethodDto;
   pointsForAttendance: number;
   featured: boolean;
+  approvalStatus: 'PENDING' | 'APPROVED' | 'REJECTED' | 'ARCHIVED';
+  rejectionReason?: string;
   attendanceCount: number;
   rsvpCount: number;
 }
@@ -105,6 +109,8 @@ export interface UpsertCampusEventDto {
   pointsForAttendance?: number;
   featured?: boolean;
   registrationUrl?: string;
+  approvalStatus?: 'PENDING' | 'APPROVED' | 'REJECTED' | 'ARCHIVED';
+  rejectionReason?: string;
 }
 
 /** Request: delete event */

--- a/server/src/campus-event/campus-event.service.ts
+++ b/server/src/campus-event/campus-event.service.ts
@@ -42,15 +42,19 @@ export class CampusEventService {
       address: ev.address ?? undefined,
       latitude: ev.latitude,
       longitude: ev.longitude,
+      checkInRadius: ev.checkInRadius,
       categories: ev.categories,
       tags: ev.tags,
       source: ev.source,
       externalUrl: ev.externalUrl ?? undefined,
       organizerName: ev.organizerName ?? undefined,
+      organizerEmail: ev.organizerEmail ?? undefined,
       registrationUrl: ev.registrationUrl ?? undefined,
       checkInMethod: ev.checkInMethod,
       pointsForAttendance: ev.pointsForAttendance,
       featured: ev.featured,
+      approvalStatus: ev.approvalStatus,
+      rejectionReason: ev.rejectionReason ?? undefined,
       attendanceCount,
       rsvpCount,
     };
@@ -158,7 +162,8 @@ export class CampusEventService {
         pointsForAttendance: dto.pointsForAttendance ?? 10,
         featured: dto.featured ?? false,
         registrationUrl: dto.registrationUrl,
-        approvalStatus: ApprovalStatus.APPROVED,
+        approvalStatus: (dto.approvalStatus as ApprovalStatus) ?? ApprovalStatus.APPROVED,
+        rejectionReason: dto.rejectionReason ?? null,
       },
     });
     await this.emitUpdateCampusEvent(ev, false);
@@ -201,6 +206,15 @@ export class CampusEventService {
         pointsForAttendance: dto.pointsForAttendance ?? 10,
         featured: dto.featured ?? false,
         registrationUrl: dto.registrationUrl,
+        approvalStatus: dto.approvalStatus
+          ? (dto.approvalStatus as ApprovalStatus)
+          : undefined,
+        rejectionReason:
+          dto.approvalStatus === 'REJECTED'
+            ? dto.rejectionReason ?? existing.rejectionReason
+            : dto.approvalStatus
+              ? null
+              : undefined,
       },
     });
     await this.emitUpdateCampusEvent(ev, false);


### PR DESCRIPTION
### Summary <!-- Required -->

This pull request is implements creating campus events in the admin dashboard. Admins can create or edit an event by filling out a form with information, approve/reject an event, and delete an event. 

- [x] added "Campus Event' to the sidebar which leads to the Campus Event page
- [x] create a form with required fields `title, description, start time, end time, location name, latitude/longitude (via MapEntryForm), categories ` and optional fields `image URL, all-day toggle (default false), address, check-in radius (default 100m), tags, organizer name, organizer email, check-in method dropdown, points for attendance (default 10), featured toggle (default false), registration URL`
- [x] once the form is filled out, the campus event is created in the backend with the given information
- [x] admins can approve/reject/archive events. If an event is rejected, a rejection reason must be filled out. 
- [x] wired a `onUpdateCampusEventData` listener so an update to one event updates the list without re-requesting the whole list 

Remaining TODOs:

- [x] check that rejection reasons are required when rejecting an event
